### PR TITLE
Move output to a separate SQLite table.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
-*~
 *.o
+*~
+.pytest_cache
 Makefile.local
-doc
-work/
-env.sh
 apsis.db
+doc
+env.sh
+work/

--- a/bin/apsis
+++ b/bin/apsis
@@ -349,7 +349,8 @@ cmd = add_command(
 #--- command: output -----------------------------------------------------------
 
 def cmd_output(client, args):
-    output = client.get_output(args.run_id)
+    # FIXME: For now, expose output_id=output only.
+    output = client.get_output(args.run_id, "output")
     sys.stdout.buffer.write(output)
 
 

--- a/notes/todo.md
+++ b/notes/todo.md
@@ -1,6 +1,7 @@
 # Current
 
 - a good set of demo jobs
+- run list  pagination
 - prevent the same instance from running more than once... HOW?
 - GitHub README
 - performance test with lots of jobs and runs

--- a/python/apsis/runs.py
+++ b/python/apsis/runs.py
@@ -3,7 +3,7 @@ from   contextlib import contextmanager
 import enum
 import itertools
 import logging
-from   ora import now, Time
+from   ora import now
 
 from   .lib.py import format_ctor
 
@@ -75,7 +75,6 @@ class Run:
         self.meta       = {}
         # User message explaining the state.
         self.message    = None
-        self.output     = None
         # State information specific to the program, for a running run.
         self.run_state  = None
 
@@ -100,7 +99,7 @@ class Run:
 
 
     def _transition(self, timestamp, state, *, meta={}, times={}, 
-                    output=None, message=None, run_state=None):
+                    message=None, run_state=None):
         # Check that this is a valid transition.
         if self.state not in self.TRANSITIONS[state]:
             raise TransitionError(self.state, state)
@@ -108,13 +107,12 @@ class Run:
         log.debug(f"transition {self.run_id}: {self.state.name} → {state.name}")
 
         # Update attributes.
-        self.timestamp  = timestamp
-        self.message    = None if message is None else str(message)
+        self.timestamp = timestamp
+        self.message = None if message is None else str(message)
         self.meta.update(meta)
         self.times[state.name] = self.timestamp
         self.times.update(times)
-        self.output     = output
-        self.run_state  = run_state
+        self.run_state = run_state
 
         # Compute and add elapsed time.
         start = self.times.get("running")

--- a/python/apsis/service/client.py
+++ b/python/apsis/service/client.py
@@ -58,8 +58,8 @@ class Client:
         return self.__get("jobs")
 
 
-    def get_output(self, run_id) -> bytes:
-        url = self.__url("runs", run_id, "output")
+    def get_output(self, run_id, output_id) -> bytes:
+        url = self.__url("runs", run_id, "output", output_id)
         logging.debug(f"GET {url}")
         resp = requests.get(url)
         resp.raise_for_status()

--- a/python/apsis/service/main.py
+++ b/python/apsis/service/main.py
@@ -12,6 +12,7 @@ from   . import api
 from   . import DEFAULT_PORT
 from   ..apsis import Apsis
 from   ..jobs import JobsDir
+from   ..output_db import OutputDB
 from   ..sqlite import SqliteDB
 
 #-------------------------------------------------------------------------------
@@ -148,34 +149,39 @@ def main():
         help="server port")
     parser.add_argument(
         "--create", action="store_true", default=False,
-        help="create a new state database")
+        help="create a new state file and exit")
     parser.add_argument(
         "jobs", metavar="JOBS", 
         help="job directory")
     parser.add_argument(
-        "db", metavar="DATABASE",
-        help="database file")
+        "state_path", metavar="PATH",
+        help="state file")
     args = parser.parse_args()
     logging.getLogger().setLevel(getattr(logging, args.log_level.upper()))
 
+    if args.create:
+        SqliteDB.create(args.db)
+        raise SystemExit(0)
+        
+    db      = SqliteDB.open(args.db)
     jobs    = JobsDir(args.jobs)
-    db      = SqliteDB(args.db, args.create)
     apsis   = Apsis(jobs, db)
 
-    loop = asyncio.get_event_loop()
-
-    server = app.create_server(
-        host        =args.host,
-        port        =args.port,
-        debug       =args.debug,
-    )
-    app.apsis = apsis
+    app.apsis   = apsis
     app.running = True
-    asyncio.ensure_future(server)
 
     # Set up the scheduler.
     asyncio.ensure_future(apsis.scheduler.loop())
 
+    # Set up the HTTP server.
+    server  = app.create_server(
+        host        =args.host,
+        port        =args.port,
+        debug       =args.debug,
+    )
+    asyncio.ensure_future(server)
+
+    loop = asyncio.get_event_loop()
     try:
         loop.run_forever()
     except KeyboardInterrupt:

--- a/python/apsis/service/main.py
+++ b/python/apsis/service/main.py
@@ -12,7 +12,6 @@ from   . import api
 from   . import DEFAULT_PORT
 from   ..apsis import Apsis
 from   ..jobs import JobsDir
-from   ..output_db import OutputDB
 from   ..sqlite import SqliteDB
 
 #-------------------------------------------------------------------------------
@@ -160,10 +159,10 @@ def main():
     logging.getLogger().setLevel(getattr(logging, args.log_level.upper()))
 
     if args.create:
-        SqliteDB.create(args.db)
+        SqliteDB.create(args.state_path)
         raise SystemExit(0)
         
-    db      = SqliteDB.open(args.db)
+    db      = SqliteDB.open(args.state_path)
     jobs    = JobsDir(args.jobs)
     apsis   = Apsis(jobs, db)
 

--- a/test/test_output_db.py
+++ b/test/test_output_db.py
@@ -1,6 +1,7 @@
 import pytest
 
 from   apsis.sqlite import SqliteDB
+from   apsis.program import OutputMetadata, Output
 
 #-------------------------------------------------------------------------------
 
@@ -13,11 +14,12 @@ def test0():
         db.get_data("r42", "output")
 
     data = b"The quick brown fox jumped over the lazy dogs.\x01\x02\x03"
-    db.add_data("r42", "output", "combined output", data)
+    output = Output(OutputMetadata("combined output", len(data)), data)
+    db.add("r42", "output", output)
 
     meta = db.get_metadata("r42")
     assert list(meta.keys()) == ["output"]
-    assert meta["output"]["name"] == "combined output"
+    assert meta["output"].name == "combined output"
 
     assert db.get_data("r42", "output") == data
 

--- a/test/test_output_db.py
+++ b/test/test_output_db.py
@@ -1,0 +1,25 @@
+import pytest
+
+from   apsis.sqlite import SqliteDB
+
+#-------------------------------------------------------------------------------
+
+def test0():
+    db = SqliteDB.create(path=None).output_db
+
+    len(db.get_metadata("r42")) == 0
+
+    with pytest.raises(LookupError):
+        db.get_data("r42", "output")
+
+    data = b"The quick brown fox jumped over the lazy dogs.\x01\x02\x03"
+    db.add_data("r42", "output", "combined output", data)
+
+    meta = db.get_metadata("r42")
+    assert list(meta.keys()) == ["output"]
+    assert meta["output"]["name"] == "combined output"
+
+    assert db.get_data("r42", "output") == data
+
+    
+

--- a/vue/src/views/RunView.vue
+++ b/vue/src/views/RunView.vue
@@ -107,7 +107,7 @@ export default {
 
     load_output() {
       const v = this
-      const url = '/api/v1/runs/' + this.run.run_id + '/output'  // FIXME
+      const url = this.run.output_url
       fetch(url)
         // FIXME: Handle failure, set error.
         .then((response) => response.text())  // FIXME: Might not be text!


### PR DESCRIPTION
The database and internal API support multiple outputs per run, but for now we only use one, with output_id="output".