### PR TITLE
Cleanup/test agent

### DIFF
--- a/python/apsis/agent/main.py
+++ b/python/apsis/agent/main.py
@@ -97,8 +97,11 @@ def get_state_dir():
     """
     Returns the state directory path, creating it if necessary.
     """
-    user = pwd.getpwuid(os.getuid()).pw_name
-    path = Path(tempfile.gettempdir()) / f"apsis-agent-{user}"
+    try:
+        path = Path(os.environ["APSIS_AGENT_STATE_DIR"])
+    except KeyError:
+        user = pwd.getpwuid(os.getuid()).pw_name
+        path = Path(tempfile.gettempdir()) / f"apsis-agent-{user}"
     with suppress(FileExistsError):
         os.mkdir(path, mode=0o700)
     os.chmod(path, 0o700)

--- a/test/int/conftest.py
+++ b/test/int/conftest.py
@@ -1,0 +1,24 @@
+import logging
+import os
+import pytest
+import shutil
+import tempfile
+
+#-------------------------------------------------------------------------------
+
+@pytest.fixture(scope="session", autouse=True)
+def agent_state_dir():
+    # This module is used in testing only.  Set the agent state dir to a unique,
+    # private path.
+    state_dir = tempfile.mkdtemp(prefix="apsis-agent-test-")
+    logging.info(f"agent state dir: {state_dir}")
+    os.environ["APSIS_AGENT_STATE_DIR"] = state_dir
+
+    yield
+
+    # Clean up the state dir.
+    logging.info(f"cleaning up agent state dir: {state_dir}")
+    del os.environ["APSIS_AGENT_STATE_DIR"]
+    shutil.rmtree(state_dir)
+
+

--- a/test/int/instance.py
+++ b/test/int/instance.py
@@ -52,7 +52,7 @@ class ApsisInstance:
         with open(self.cfg_path, "w") as file:
             yaml.dump(self.cfg, file)
 
- 
+
     def start_serve(self):
         assert self.cfg is not None
         assert self.srv_proc is None

--- a/test/int/test_output.py
+++ b/test/int/test_output.py
@@ -11,14 +11,14 @@ from   instance import ApsisInstance
 job_dir = Path(__file__).absolute().parent / "test_output_jobs"
 
 @pytest.fixture(scope="module")
-def inst():
+def inst(agent_state_dir):
     with closing(ApsisInstance(job_dir=job_dir)) as inst:
         inst.create_db()
         inst.write_cfg()
         inst.start_serve()
         inst.wait_for_serve()
         yield inst
- 
+
 
 @pytest.fixture
 def client(inst, scope="module"):
@@ -27,7 +27,7 @@ def client(inst, scope="module"):
 
 #-------------------------------------------------------------------------------
 
-def test_output(client):
+def test_output_basic(client):
     res = client.schedule("printf", {"string": "hello\n"})
     run_id = res["run_id"]
     # FIXME


### PR DESCRIPTION
When running integration tests, use a private agent state dir, so we don't reuse or interfere with any other agent that might be running on any host.