### PR TITLE
Fix/compressed output

### DIFF
--- a/python/apsis/lib/api.py
+++ b/python/apsis/lib/api.py
@@ -32,6 +32,24 @@ def to_bool(string):
         raise ValueError(f"unknown bool: {string}")
 
 
+def decompress(data, compression) -> bytes:
+    """
+    Decompresses `data` assuming it is compressed with `compression`.
+    """
+    match compression:
+        case "br":
+            data = brotli.decompress(data)
+        case "deflate":
+            data = zlib.decompress(data)
+        case "gzip":
+            data = gzip.decompress(data)
+        case None:
+            pass
+        case _:
+            raise RuntimeError(f"can't decompress: {compression}")
+    return data
+
+
 def encode_response(headers, data, compression):
     """
     Encodes data for a response.
@@ -55,17 +73,7 @@ def encode_response(headers, data, compression):
 
     else:
         # Use identity, which is always implicitly acceptable.
-        match compression:
-            case "br":
-                data = brotli.decompress(data)
-            case "deflate":
-                data = zlib.decompress(data)
-            case "gzip":
-                data = gzip.decompress(data)
-            case None:
-                pass
-            case _:
-                raise RuntimeError(f"can't decompress: {compression}")
+        data = decompress(data, compression)
         encoding = "identity"
 
     return {"Content-Encoding": encoding}, data

--- a/python/apsis/program.py
+++ b/python/apsis/program.py
@@ -9,6 +9,7 @@ import traceback
 
 from   .agent.client import Agent, NoSuchProcessError
 from   .host_group import expand_host
+from   .lib.api import decompress
 from   .lib.json import TypedJso, check_schema
 from   .lib.py import or_none, nstr
 from   .lib.sys import get_username
@@ -43,13 +44,20 @@ class Output:
         :param metadata:
           Information about the data.
         :param data:
-          The data bytes.
+          The data bytes; these may be compressed.
         :pamam compression:
           The compresison type, or `None` for uncompressed.
         """
         self.metadata       = metadata
         self.data           = data
         self.compression    = compression
+
+
+    def get_uncompressed_data(self) -> bytes:
+        """
+        Returns the output data, decompressing if necessary.
+        """
+        return decompress(self.data, self.compression)
 
 
 

--- a/test/int/output/test_output.py
+++ b/test/int/output/test_output.py
@@ -1,3 +1,4 @@
+import brotli
 from   contextlib import closing
 from   pathlib import Path
 import pytest
@@ -53,7 +54,11 @@ def test_large_output_compression(inst):
     res = client.get_run(run_id)
     assert res["state"] == "success"
 
-    # Examine the output in the database.
+    # Get the output from the client.
+    output = client.get_output(run_id, "output")
+    assert len(output) == 1048576
+
+    # Examine the output directly in the database.
     with sqlite3.connect(inst.db_path) as conn:
         cursor = conn.execute(
             """
@@ -70,5 +75,6 @@ def test_large_output_compression(inst):
         assert length == 1048576
         assert compression == "br"
         assert len(data) < 1024  # compresses real nice
+        assert len(brotli.decompress(data)) == 1048576
 
 

--- a/test/unit/test_output_db.py
+++ b/test/unit/test_output_db.py
@@ -1,3 +1,4 @@
+import brotli
 import pytest
 
 from   apsis.sqlite import SqliteDB
@@ -5,7 +6,7 @@ from   apsis.program import OutputMetadata, Output
 
 #-------------------------------------------------------------------------------
 
-def test0():
+def test_basic():
     db = SqliteDB.create(path=None).output_db
 
     len(db.get_metadata("r42")) == 0
@@ -22,5 +23,26 @@ def test0():
     assert meta["output"].name == "combined output"
 
     assert db.get_output("r42", "output").data == data
+
+
+def test_br(tmp_path):
+    DATA = bytes(range(256)) * 40960  # 10 MB; definitely not UTF-8.
+    path = tmp_path / "apsis.db"
+
+    db = SqliteDB.create(path=path).output_db
+    db.add("r99", "test", Output(
+        OutputMetadata("program output", len(DATA)),
+        brotli.compress(DATA), "br",
+    ))
+
+    db = SqliteDB.open(path).output_db
+    output = db.get_output("r99", "test")
+    assert output.metadata.name == "program output"
+    assert output.metadata.length == 10485760
+    assert output.metadata.content_type == "application/octet-stream"
+    assert output.compression == "br"
+    assert len(output.data) < 1024
+    data = output.get_uncompressed_data()
+    assert data == DATA
 
 


### PR DESCRIPTION
With this, you can,
```py
output = apsis.outputs.get_output(run_id, "output").get_uncompressed_data()
```
