### PR TITLE
Feature/compress in apsis

### DIFF
--- a/python/apsis/lib/cmpr.py
+++ b/python/apsis/lib/cmpr.py
@@ -1,0 +1,40 @@
+import asyncio
+import logging
+from   pathlib import Path
+import shlex
+
+log = logging.getLogger(__name__)
+
+BROTLI = Path("/usr/bin/brotli")
+
+#-------------------------------------------------------------------------------
+
+async def compress_async(data, compression) -> bytes:
+    """
+    Compresses `data` with `compression`.
+
+    :raise RuntimeError:
+      Compression failed.
+    """
+    if compression is None:
+        return data
+
+    elif compression == "br":
+        argv = (str(BROTLI), "--stdout", "--quality=3")
+        log.info(f"compressing: {shlex.join(argv)}")
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            stdin   =asyncio.subprocess.PIPE,
+            stdout  =asyncio.subprocess.PIPE,
+            stderr  =asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate(input=data)
+        if proc.returncode == 0:
+            return stdout
+        else:
+            raise RuntimeError("compression failed: {proc.returncode}: {stderr}")
+
+    else:
+        raise NotImplementedError(f"compression: {compression}")
+
+

--- a/test/unit/test_cmpr.py
+++ b/test/unit/test_cmpr.py
@@ -1,0 +1,19 @@
+import brotli
+import pytest
+
+from   apsis.lib.cmpr import compress_async
+
+#-------------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_compress_async():
+    data = b"alkjsdhtlkqjhwetrnabsdcvlkjhqaweljkh" * 1024
+
+    compressed = await compress_async(data, None)
+    assert compressed == data
+
+    compressed = await compress_async(data, "br")
+    assert len(compressed) < len(data)
+    assert brotli.decompress(compressed) == data
+
+

--- a/test/unit/test_cmpr.py
+++ b/test/unit/test_cmpr.py
@@ -1,3 +1,4 @@
+import asyncio
 import brotli
 import pytest
 
@@ -15,5 +16,31 @@ async def test_compress_async():
     compressed = await compress_async(data, "br")
     assert len(compressed) < len(data)
     assert brotli.decompress(compressed) == data
+
+
+@pytest.mark.asyncio
+async def test_compress_async_timing():
+    """
+    Tests that compress_async() allows other coros to run concurrently.
+    """
+    data = b"alkjsdhtlkqjhwetrnabsdcvlkjhqaweljkh" * 1048576
+
+    check = 0
+    async def background():
+        nonlocal check
+        for i in range(1000):
+            await asyncio.sleep(0.0001)
+            check += i
+        return check
+
+    # Start the background task.
+    task = asyncio.create_task(background())
+    # It hasn't been scheduled yet.
+    assert not check
+
+    _ = await compress_async(data, "br")
+    # background() should have run concurrently.
+    assert check > 0
+    assert await task == 499500
 
 


### PR DESCRIPTION
Rather than compressing output in the agent, compress it in Apsis.  This requires an async wrapper to the compression function, to avoid hanging the scheduler when compressing a large output.

Resolves #244 
