### PR TITLE
Cache Ora calendars.

### DIFF
--- a/python/apsis/lib/calendar.py
+++ b/python/apsis/lib/calendar.py
@@ -1,0 +1,10 @@
+import functools
+import ora.calendar
+
+#-------------------------------------------------------------------------------
+
+# Cache calendars.  We assume on-disk calendars don't change during the
+# scheduler's lifetime.
+get_calendar = functools.cache(ora.calendar.get_calendar)
+
+

--- a/python/apsis/runs.py
+++ b/python/apsis/runs.py
@@ -8,6 +8,7 @@ import ora
 from   ora import now, Time
 import shlex
 
+from   .lib.calendar import get_calendar
 from   .lib.memo import memoize
 from   .lib.py import format_ctor, iterize
 
@@ -273,9 +274,9 @@ BIND_ARGS = {
                 "Daytime",
                 "Time",
                 "TimeZone",
-                "get_calendar",
         )
     },
+    "get_calendar": get_calendar,
 }
 
 def get_bind_args(run):

--- a/python/apsis/schedule/daily.py
+++ b/python/apsis/schedule/daily.py
@@ -1,6 +1,7 @@
 import logging
 import ora
 
+from   apsis.lib.calendar import get_calendar
 from   apsis.lib.json import check_schema, to_array
 from   .base import Schedule
 
@@ -117,7 +118,7 @@ class DailySchedule(Schedule):
             enabled     = pop("enabled", bool, default=True)
             args        = pop("args", default={})
             tz          = pop("tz", ora.TimeZone)
-            calendar    = ora.get_calendar(pop("calendar", default="all"))
+            calendar    = get_calendar(pop("calendar", default="all"))
             daytimes    = to_array(pop("daytime"))
             daytimes    = [ ora.Daytime(d) for d in daytimes ]
             date_shift  = pop("date_shift", int, default=0)

--- a/python/apsis/schedule/daily_interval.py
+++ b/python/apsis/schedule/daily_interval.py
@@ -1,6 +1,7 @@
 import logging
 import ora
 
+from   apsis.lib.calendar import get_calendar
 from   apsis.lib.json import check_schema
 from   .base import Schedule, DaytimeSpec
 
@@ -111,7 +112,7 @@ class DailyIntervalSchedule(Schedule):
     def from_jso(cls, jso):
         with check_schema(jso) as pop:
             tz          = pop("tz", ora.TimeZone)
-            calendar    = ora.get_calendar(pop("calendar", default="all"))
+            calendar    = get_calendar(pop("calendar", default="all"))
             start       = DaytimeSpec.from_jso(pop("start"))
             stop        = DaytimeSpec.from_jso(pop("stop"))
             interval    = pop("interval", int)


### PR DESCRIPTION
This drastically reduces memory use when there are lots of _daily_ or _daily_interval_ jobs, and avoids further memory waste when reloading jobs.