### PR TITLE
Add internal programs.  Make stats an internal program.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ work/
 python/apsis.egg-info
 .cache/
 config.yaml
+stats/

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,8 @@
   runs.
 - The Ora functions `from_local` and `to_local` are available in jinja2
   expressions when binding jobs.
+- Apsis no longer logs stats to its own logs.  Instead, schedule a
+  `StatsProgram` job to collect Apsis usage stats.
 
 
 # v0.16.0

--- a/docs/programs.rst
+++ b/docs/programs.rst
@@ -94,3 +94,32 @@ The remote program is launched via SSH and monitored by an agent program.
 FIXME: Document this better.
 
 
+Internal Programs
+-----------------
+
+An *internal program* is a special program that operates on Apsis itself.  These
+internal program types are available:
+
+
+Stats
+^^^^^
+
+A `apsis.program.internal.stats` program generates internal statistics about
+Apsis's state and resource use, in JSON format.  Stats are generated as program
+output.  If you specify the `path` key, the JSON stats are also appended, with a
+newline, to the specified file.
+
+This job produces a run once a minute, which appends the stats to a dated file:
+
+.. code:: yaml
+
+    params: [date]
+
+    schedule:
+        type: interval
+        interval: 60
+
+    program:
+        type: apsis.program.internal.stats.StatsProgram
+        path: "/path/to/apsis/stats/{{ date }}.json"
+

--- a/jobs/internal/stats.yaml
+++ b/jobs/internal/stats.yaml
@@ -1,0 +1,10 @@
+params: [date]
+
+schedule:
+  type: interval
+  interval: 60
+
+program:
+  type: apsis.program.internal.stats.StatsProgram
+  path: "/home/alex/dev/apsis/stats/{{ date }}.json"
+

--- a/python/apsis/apsis.py
+++ b/python/apsis/apsis.py
@@ -11,7 +11,7 @@ from   .exc import TimeoutWaiting
 from   .host_group import config_host_groups
 from   .jobs import Jobs, load_jobs_dir, diff_jobs_dirs
 from   .lib.asyn import cancel_task
-from   .program import ProgramError, ProgramFailure, Output, OutputMetadata
+from   .program.base import InternalProgram, Output, OutputMetadata, ProgramError, ProgramFailure
 from   . import runs
 from   .run_log import RunLog
 from   .runs import Run, RunStore, RunError, MissingArgumentError, ExtraArgumentError
@@ -247,7 +247,11 @@ class Apsis:
 
         async def start():
             try:
-                running, coro = await run.program.start(run.run_id, self.cfg)
+                if isinstance(run.program, InternalProgram):
+                    start = run.program.start(run.run_id, self)
+                else:
+                    start = run.program.start(run.run_id, self.cfg)
+                running, coro = await start
 
             except ProgramError as exc:
                 # Program failed to start.

--- a/python/apsis/apsis.py
+++ b/python/apsis/apsis.py
@@ -11,7 +11,7 @@ from   .exc import TimeoutWaiting
 from   .host_group import config_host_groups
 from   .jobs import Jobs, load_jobs_dir, diff_jobs_dirs
 from   .lib.asyn import cancel_task
-from   .program.base import InternalProgram, Output, OutputMetadata, ProgramError, ProgramFailure
+from   .program.base import _InternalProgram, Output, OutputMetadata, ProgramError, ProgramFailure
 from   . import runs
 from   .run_log import RunLog
 from   .runs import Run, RunStore, RunError, MissingArgumentError, ExtraArgumentError
@@ -246,7 +246,7 @@ class Apsis:
 
         async def start():
             try:
-                if isinstance(run.program, InternalProgram):
+                if isinstance(run.program, _InternalProgram):
                     start = run.program.start(run.run_id, self)
                 else:
                     start = run.program.start(run.run_id, self.cfg)

--- a/python/apsis/apsis.py
+++ b/python/apsis/apsis.py
@@ -1,5 +1,4 @@
 import asyncio
-import json
 import logging
 from   mmap import PAGESIZE
 from   ora import now, Time
@@ -82,7 +81,6 @@ class Apsis:
         self.scheduler = Scheduler(cfg, self.jobs, self.schedule, stop_time)
 
         self.__retire_loop = asyncio.ensure_future(self.retire_loop())
-        self.__stats_loop = asyncio.ensure_future(self.stats_loop())
 
 
     async def restore(self):
@@ -670,17 +668,6 @@ class Apsis:
                 return
 
             await asyncio.sleep(60)
-
-
-    async def stats_loop(self):
-        while True:
-            try:
-                stats = self.get_stats()
-            except Exception:
-                log.error("stats failed", exc_info=True)
-            else:
-                log.info("stats: " + json.dumps(stats))
-            await asyncio.sleep(10)
 
 
 

--- a/python/apsis/apsis.py
+++ b/python/apsis/apsis.py
@@ -621,6 +621,7 @@ class Apsis:
         res = resource.getrusage(resource.RUSAGE_SELF)
         livequery_queues = self.run_store._RunStore__queues
         stats = {
+            "time"                  : str(now()),
             "rusage_maxrss"         : res.ru_maxrss * 1024,
             "rusage_utime"          : res.ru_utime,
             "rusage_stime"          : res.ru_stime,

--- a/python/apsis/apsis.py
+++ b/python/apsis/apsis.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+from   mmap import PAGESIZE
 from   ora import now, Time
 import resource
 import sys
@@ -642,8 +643,8 @@ class Apsis:
             pass
         else:
             stats.update({
-                "statm_size"        : statm[0],
-                "statm_resident"    : statm[1],
+                "statm_size"        : statm[0] * PAGESIZE,
+                "statm_resident"    : statm[1] * PAGESIZE,
             })
 
         return stats

--- a/python/apsis/program/base.py
+++ b/python/apsis/program/base.py
@@ -170,3 +170,24 @@ class Program(TypedJso):
 
 
 
+#-------------------------------------------------------------------------------
+
+class InternalProgram(Program):
+
+    def bind(self, args):
+        pass
+
+
+    async def start(self, run_id, apsis):
+        pass
+
+
+    def reconnect(self, run_id, run_state):
+        pass
+
+
+    async def signal(self, run_id, signum: str):
+        pass
+
+
+

--- a/python/apsis/program/base.py
+++ b/python/apsis/program/base.py
@@ -172,7 +172,12 @@ class Program(TypedJso):
 
 #-------------------------------------------------------------------------------
 
-class InternalProgram(Program):
+class _InternalProgram(Program):
+    """
+    Program type for internal use.
+
+    Not API.  Do not use in extension code.
+    """
 
     def bind(self, args):
         pass

--- a/python/apsis/program/internal/stats.py
+++ b/python/apsis/program/internal/stats.py
@@ -52,13 +52,10 @@ class StatsProgram(InternalProgram):
 
     async def wait(self, apsis):
         stats = json.dumps(apsis.get_stats())
-        if self.__path is None:
-            outputs = program_outputs(stats.encode())
-        else:
+        if self.__path is not None:
             with open(self.__path, "a") as file:
                 print(stats, file=file)
-            outputs = {}
-        return ProgramSuccess(outputs=outputs)
+        return ProgramSuccess(outputs=program_outputs(stats.encode()))
 
 
     def reconnect(self, run_id, run_state):

--- a/python/apsis/program/internal/stats.py
+++ b/python/apsis/program/internal/stats.py
@@ -1,0 +1,73 @@
+import json
+import logging
+
+from   apsis.lib.json import check_schema
+from   apsis.lib.py import or_none, nstr
+from   apsis.runs import template_expand
+from   ..base import InternalProgram, ProgramRunning, ProgramSuccess, program_outputs
+
+log = logging.getLogger(__name__)
+
+#-------------------------------------------------------------------------------
+
+class StatsProgram(InternalProgram):
+    """
+    A program that collects and dumps Apsis internal stats in JSON format.
+    """
+
+    def __init__(self, *, path=None):
+        self.__path = path
+
+
+    def __str__(self):
+        res = "internal stats"
+        if self.__path is not None:
+            res += f"→ {self.__path}"
+        return res
+
+
+    def bind(self, args):
+        path = or_none(template_expand)(self.__path, args)
+        return type(self)(path=path)
+
+
+    @classmethod
+    def from_jso(cls, jso):
+        with check_schema(jso) as pop:
+            path = pop("path", nstr, None)
+        return cls(path=path)
+
+
+    def to_jso(self):
+        return {
+            **super().to_jso(),
+            "path": self.__path,
+        }
+
+
+    async def start(self, run_id, apsis):
+        run_state = {}
+        return ProgramRunning(run_state), self.wait(apsis)
+
+
+    async def wait(self, apsis):
+        stats = json.dumps(apsis.get_stats())
+        if self.__path is None:
+            outputs = program_outputs(stats.encode())
+        else:
+            with open(self.__path, "a") as file:
+                print(stats, file=file)
+            outputs = {}
+        return ProgramSuccess(outputs=outputs)
+
+
+    def reconnect(self, run_id, run_state):
+        # FIXME
+        assert False
+
+
+    async def signal(self, run_state, signum):
+        pass
+
+
+

--- a/python/apsis/program/internal/stats.py
+++ b/python/apsis/program/internal/stats.py
@@ -4,13 +4,13 @@ import logging
 from   apsis.lib.json import check_schema
 from   apsis.lib.py import or_none, nstr
 from   apsis.runs import template_expand
-from   ..base import InternalProgram, ProgramRunning, ProgramSuccess, program_outputs
+from   ..base import _InternalProgram, ProgramRunning, ProgramSuccess, program_outputs
 
 log = logging.getLogger(__name__)
 
 #-------------------------------------------------------------------------------
 
-class StatsProgram(InternalProgram):
+class StatsProgram(_InternalProgram):
     """
     A program that collects and dumps Apsis internal stats in JSON format.
     """

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setuptools.setup(
         "apsis.lib",
         "apsis.lib.itr",
         "apsis.program",
+        "apsis.program.internal",
         "apsis.schedule",
         "apsis.service",
     ],

--- a/test/int/test_stats.py
+++ b/test/int/test_stats.py
@@ -1,0 +1,48 @@
+from   contextlib import closing
+import json
+import ora
+import time
+
+from   instance import ApsisInstance
+
+#-------------------------------------------------------------------------------
+
+def test_stats(tmp_path):
+    path = tmp_path / "stats.json"
+
+    with closing(ApsisInstance()) as inst:
+        inst.create_db()
+        inst.write_cfg()
+        inst.start_serve()
+        inst.wait_for_serve()
+
+        client = inst.client
+
+        res = client.schedule_adhoc("now", {
+            "program": {
+                "type": "apsis.program.internal.stats.StatsProgram",
+                "path": str(path),
+            },
+        })
+        time.sleep(0.2)
+        assert client.get_run(res["run_id"])["state"] == "success"
+
+        res = client.schedule_adhoc("now", {
+            "program": {
+                "type": "apsis.program.internal.stats.StatsProgram",
+                "path": str(path),
+            },
+        })
+        time.sleep(0.2)
+        assert client.get_run(res["run_id"])["state"] == "success"
+
+        with open(path) as file:
+            stats0 = json.loads(next(file))
+            stats1 = json.loads(next(file))
+        assert round(ora.Time(stats1["time"]) - ora.Time(stats0["time"]), 1) == 0.2
+        assert int(stats0["num_running_tasks"]) == 1
+        assert int(stats0["num_scheduled_entries"]) == 0
+        assert int(stats1["num_running_tasks"]) == 1
+        assert int(stats1["num_scheduled_entries"]) == 0
+
+


### PR DESCRIPTION
Adds a special "internal" program type, so that periodic internal Apsis processes can be scheduled as ordinary jobs.  This program type is not part of the external API.  Moves stats from a periodic job in logging to an internal program type.