### PR TITLE
Fix/agent retry

### DIFF
--- a/jobs/test/remote command.yaml
+++ b/jobs/test/remote command.yaml
@@ -1,26 +1,17 @@
-params: [message, host, user]
+params: [message, host]
 
 metadata:
-  description: Test job that runs a program on a remote host.
+  description: Test job that runs a shell command on a remote host.
 
 schedule:
 - type: daily
-  args: {message: "Hello from sage.", host: sage, user: alex}
+  args: {message: "Hello from sage.", host: sage}
   tz: US/Eastern
   daytime:
   - 12:00:00
 
-- type: daily
-  args: {message: "Hello from fennel.", host: soho.indetermi.net, user: alex}
-  tz: US/Eastern
-  daytime:
-  - 12:00:00
-
-program: 
-  type: program
-  argv: 
-  - /home/alex/dev/apsis/jobs/test/test0 
-  - "{{ message }}"
+program:
+  type: shell
+  command: $HOME/dev/apsis/jobs/test/test0 "{{ message }}"
   host: "{{ host }}"
-  user: "{{ user }}"
 

--- a/jobs/test/remote program.yaml
+++ b/jobs/test/remote program.yaml
@@ -1,17 +1,26 @@
-params: [message, host]
+params: [message, host, user]
 
 metadata:
-  description: Test job that runs a shell command on a remote host.
+  description: Test job that runs a program on a remote host.
 
 schedule:
 - type: daily
-  args: {message: "Hello from sage.", host: sage}
+  args: {message: "Hello from sage.", host: sage, user: alex}
   tz: US/Eastern
   daytime:
   - 12:00:00
 
-program:
-  type: shell
-  command: $HOME/dev/apsis/jobs/test/test0 "{{ message }}"
+- type: daily
+  args: {message: "Hello from fennel.", host: soho.indetermi.net, user: alex}
+  tz: US/Eastern
+  daytime:
+  - 12:00:00
+
+program: 
+  type: program
+  argv: 
+  - /home/alex/dev/apsis/jobs/test/test0 
+  - "{{ message }}"
   host: "{{ host }}"
+  user: "{{ user }}"
 

--- a/python/apsis/agent/client.py
+++ b/python/apsis/agent/client.py
@@ -525,13 +525,13 @@ class Agent:
             raise NoSuchProcessError(proc_id)
 
 
-    async def del_process(self, proc_id):
+    async def del_process(self, proc_id, *, client=None):
         """
         Deltes a process.  The process may not be running.
         """
         path = f"/processes/{proc_id}"
         try:
-            async with self.__request("DELETE", path) as rsp:
+            async with self.__request("DELETE", path, client=client) as rsp:
                 return (await _get_jso(rsp))["stop"]
 
         except NotFoundError:

--- a/python/apsis/agent/client.py
+++ b/python/apsis/agent/client.py
@@ -145,6 +145,11 @@ def _get_http_client(loop):
         # generate a certificate for each agent host.  For now at least we have
         # connection encryption.
         verify=False,
+        # FIXME: Don't use keepalive in general, until we understand the
+        # disconnect issues.
+        limits=httpx.Limits(
+            max_keepalive_connections=0,
+        ),
     )
     # When the loop closes, close the client first.  Otherwise, we leak tasks
     # and fds, and asyncio complains about them at shutdown.
@@ -343,6 +348,7 @@ class Agent:
             *,
             args={},
             restart=False,
+            client=None,
     ):
         """
         Context manager for an HTTP request to the agent.  The value is the
@@ -365,6 +371,9 @@ class Agent:
         # Delays in sec before each attempt to connect.
         delays = self.START_DELAYS if restart else [0]
 
+        if client is None:
+            client = get_http_client()
+
         for delay in delays:
             if delay > 0:
                 await asyncio.sleep(delay)
@@ -379,7 +388,7 @@ class Agent:
                 )
 
             try:
-                rsp = await get_http_client().request(
+                rsp = await client.request(
                     method, url,
                     headers={
                         # The auth header, so the agent accepts us.
@@ -482,20 +491,20 @@ class Agent:
             return (await _get_jso(rsp))["process"]
 
 
-    async def get_process(self, proc_id, *, restart=False):
+    async def get_process(self, proc_id, *, restart=False, client=None):
         """
         Returns information about a process.
         """
         path = f"/processes/{proc_id}"
         try:
-            async with self.__request("GET", path, restart=restart) as rsp:
+            async with self.__request("GET", path, restart=restart, client=client) as rsp:
                 return (await _get_jso(rsp))["process"]
 
         except NotFoundError:
             raise NoSuchProcessError(proc_id)
 
 
-    async def get_process_output(self, proc_id, *, compression=None):
+    async def get_process_output(self, proc_id, *, compression=None, client=None):
         """
         Returns process output.
 
@@ -506,7 +515,7 @@ class Agent:
         path = f"/processes/{proc_id}/output"
         args = {} if compression is None else {"compression": compression}
         try:
-            async with self.__request("GET", path, args=args) as rsp:
+            async with self.__request("GET", path, args=args, client=client) as rsp:
                 length = int(rsp.headers["X-Raw-Length"])
                 cmpr = rsp.headers.get("X-Compression", None)
                 assert cmpr == compression

--- a/python/apsis/program/agent.py
+++ b/python/apsis/program/agent.py
@@ -244,7 +244,7 @@ class AgentProgram(Program):
         :type signal:
           Signal name or number.
         """
-        log.info(f"sending signal: {run_id}: {self.__timeout.signal}")
+        log.info(f"sending signal: {run_id}: {signal}")
         proc_id = run_state["proc_id"]
         agent = self.__get_agent(run_state["host"])
         await agent.signal(proc_id, signal)

--- a/test/int/output/test_output.py
+++ b/test/int/output/test_output.py
@@ -32,7 +32,7 @@ def test_output_basic(client):
     res = client.schedule("printf", {"string": "hello\n"})
     run_id = res["run_id"]
     # FIXME
-    sleep(0.25)
+    sleep(0.5)
     res = client.get_run(run_id)
     assert res["state"] == "success"
 


### PR DESCRIPTION
Attempt to work around the still-not-understood intermittent `httpcore.RemoteProtocolError: Server disconnected without sending a response.` and similar problems.  The issue appears to stem from HTTPX's `AsyncClient` and how it detects whether a used connection is still open, before choosing it for reuse.  Under some circumstances, it believes the connection still to be open, even though the server has closed it.  (This appears to occur intermittently if the previous use of the connection was slow to respond, so that the server decided to timeout the connection before the previous request was even done.  But I'm not sure of this.)

The approach is to disable connection reuse in general.  But we don't want this when polling a running program; the SSL setup is expensive.  So we use a single-connection pool with reuse _per running program_.  There is no connection reuse across programs.

We also set the client-side connection timeout to 30 s, far less than the server side timeout of 60 s.  The client timeout has to be larger because the client and server seem to measure the timeout from different starting points.

So, in principle, the server should never timeout and close a connection.

