### PR TITLE
Select aiohttp with env var APSIS_ASYNC_HTTP=aiohttp.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
 
 requires-python = ">=3.10"
 dependencies = [
+    "aiohttp",
     "brotli",
     "httpx",
     "jinja2",


### PR DESCRIPTION
With `APSIS_ASYNC_HTTP=httpx` (default), use HTTPX.  With `APSIS_ASYNC_HTTP=aiohttp`, use aiohttp instead.
