### PR TITLE
Fix/start waiting exc

### DIFF
--- a/python/apsis/lib/asyn.py
+++ b/python/apsis/lib/asyn.py
@@ -46,18 +46,17 @@ async def cancel_task(task, name, log):
     """
     Cancels and cleans up `task`, with logging as `name`.
     """
-    log.info(f"canceling {name} task")
     if task.cancelled():
-        log.info(f"{name} task already cancelled")
+        log.info(f"task already cancelled: {name}")
     else:
         task.cancel()
 
     try:
         return await task
     except asyncio.CancelledError:
-        log.info(f"{name} task cancelled")
+        log.info(f"task cancelled: {name}")
     except Exception:
-        log.error(f"{name} task raised", exc_info=True)
+        log.error(f"task cancelled with exc: {name}", exc_info=True)
 
 
 async def communicate(proc, timeout=None):


### PR DESCRIPTION
Fixes this: When starting a waiting run:
```
2023-08-04T17:52:44.851 asyncio                  E Exception in callback <function Apsis.__wait.<locals>.<lambda> at 0x7f7316a184c0>
handle: <Handle Apsis.__wait.<locals>.<lambda> created at /home/alex/dev/apsis/python/apsis/service/main.py:189>
source_traceback: Object created at (most recent call last):
  File "/home/alex/dev/apsis/env/bin/apsisctl", line 8, in <module>
    sys.exit(main())
  File "/home/alex/dev/apsis/python/apsis/ctl.py", line 214, in main
    status = args.cmd(args)
  File "/home/alex/dev/apsis/python/apsis/ctl.py", line 147, in cmd_serve
    restart = apsis.service.main.serve(
  File "/home/alex/dev/apsis/python/apsis/service/main.py", line 189, in serve
    loop.run_forever()
Traceback (most recent call last):
  File "uvloop/cbhandles.pyx", line 63, in uvloop.loop.Handle._run
  File "/home/alex/dev/apsis/python/apsis/apsis.py", line 234, in <lambda>
    task.add_done_callback(lambda _: self.__wait_tasks.pop(run))
KeyError: Run('r47698', Instance('test/dep/dep1', {'foo': 'sdfg', 'label': 'asdfg'}), state=<Run.STATE.starting: 4>)
```