### PR TITLE
liveness and stats endpoints

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,9 @@
 
 - Add `apsis.action.ThreadAction`, a base class for an action that runs
   synchronously in a separate thread.
+- Add `/api/v1/live` and `/api/v1/stats` endpoints, to monitor basic liveness
+  and stats, respectively.
+- Add estimate of async event loop latency to stats.
 
 
 # v0.18

--- a/python/apsis/service/api.py
+++ b/python/apsis/service/api.py
@@ -29,6 +29,11 @@ def no_such_process_error(request, exception):
     return error(exception, status=400)
 
 
+@API.route("/alive")
+async def live(request):
+    return response_json({})
+
+
 #-------------------------------------------------------------------------------
 
 def to_state(state):

--- a/python/apsis/service/api.py
+++ b/python/apsis/service/api.py
@@ -34,6 +34,12 @@ async def live(request):
     return response_json({})
 
 
+@API.route("/stats")
+async def stats(request):
+    stats = request.app.apsis.get_stats()
+    return response_json(stats)
+
+
 #-------------------------------------------------------------------------------
 
 def to_state(state):

--- a/python/apsis/service/client.py
+++ b/python/apsis/service/client.py
@@ -68,10 +68,10 @@ class Client:
         ))
 
 
-    def __request(self, method, *path, data=None, **query):
+    def __request(self, method, *path, timeout=None, data=None, **query):
         url = self.__url(*path, **query)
         logging.debug(f"{method} {url} data={data}")
-        resp = requests.request(method, url, json=data)
+        resp = requests.request(method, url, json=data, timeout=timeout)
         if 200 <= resp.status_code < 300:
             return resp.json()
         else:
@@ -94,6 +94,20 @@ class Client:
 
     def __put(self, *path, data=None, **query):
         return self.__request("PUT", *path, data=data, **query)
+
+
+    def alive(self, timeout):
+        """
+        Checks liveness of the service.
+
+        :param timeout:
+          Timeout in sec.
+        """
+        _ = self.__get("/api/v1/alive", timeout=timeout)
+
+
+    def stats(self):
+        return self.__get("/api/v1/stats")
 
 
     def skip(self, run_id):


### PR DESCRIPTION
- Add `/api/v1/live` and `/api/v1/stats` endpoints, to monitor basic liveness and stats, respectively.
- Add estimate of async event loop latency to stats.

To check liveness, with a 15 s timeout:
```py
>>> from apsis.service.client import Client
>>> Client().alive(timeout=15)
```

To peek at the current latency:
```py
>>> Client().stats()["async"]["latency"]
```
I see typically ~3 ms when Apsis is idle.

