### PR TITLE
Fix/run snapshot

### DIFF
--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -30,9 +30,9 @@ used like this in a job config:
 Actions
 ```````
 
-To add an additional action to Apsis, extend the `apsis.action.Action` class and
-implement `__call__()`.  Note that each action is run in a separate async tasks,
-which means,
+To add an additional action to Apsis, extend the `apsis.action.BaseAction` class
+and implement the async `__call__()` method.  Note that each action is run in a
+separate async tasks, which means,
 
 1. It must not block the async event loop.
 
@@ -41,7 +41,6 @@ which means,
 3. The run may transition while the action is running.  The `Run` object passed
    to the action is a copy, however, and will not reflect further transitions.
 
-Alternately, extend the `apsis.action.ThreadAction` class and implement `run()`.
-The implementation should be synchronous and may block.
-
+Alternately, extend the `apsis.action.ThreadAction` class and implement `run()`,
+which is not async.  The implementation may block, but must be threadsafe.
 

--- a/python/apsis/actions/schedule.py
+++ b/python/apsis/actions/schedule.py
@@ -1,6 +1,6 @@
 import logging
 
-from   .base import Action
+from   .base import BaseAction
 from   .condition import Condition
 from   apsis.lib.json import check_schema
 from   apsis.runs import template_expand, Instance, Run
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 
 #-------------------------------------------------------------------------------
 
-class ScheduleAction(Action):
+class ScheduleAction(BaseAction):
     """
     Schedules a new run.
     """

--- a/python/apsis/actions/test.py
+++ b/python/apsis/actions/test.py
@@ -4,7 +4,7 @@ Action types for testing.
 
 import logging
 
-from   .base import ThreadAction
+from   .base import BaseAction, ThreadAction
 from   .condition import Condition
 from   apsis.lib import py
 from   apsis.lib.json import check_schema
@@ -60,6 +60,33 @@ class ErrorThreadAction(ThreadAction):
     def run(self, run):
         log.info("error action")
         raise RuntimeError("something went wrong")
+
+
+    @classmethod
+    def from_jso(cls, jso):
+        with check_schema(jso) as pop:
+            condition   = pop("condition", Condition.from_jso, None)
+        return cls(condition=condition)
+
+
+
+class LogAction(BaseAction):
+    """
+    Action that dumps out contents of the run snapshot.
+    """
+
+    async def __call__(self, apsis, run):
+        log.info(f"run ID: {run.run_id}")
+        log.info(f"run: {run}")
+        log.info(f"job: {run.job}")
+        log.info(f"output: {run.outputs['output'].get_uncompressed_data().decode()}")
+
+
+    @classmethod
+    def from_jso(cls, jso):
+        with check_schema(jso) as pop:
+            condition   = pop("condition", Condition.from_jso, None)
+        return cls(condition=condition)
 
 
 

--- a/python/apsis/run_snapshot.py
+++ b/python/apsis/run_snapshot.py
@@ -22,7 +22,7 @@ class RunSnapshot:
     conds: Sequence[Condition]
     program: Program
     meta: Mapping[str, object]
-    output: Mapping[str, Output]
+    outputs: Mapping[str, Output]
 
     def __repr__(self):
         return py.format_ctor(self, self.run_id, self.inst, state=self.state)
@@ -37,8 +37,8 @@ def snapshot_run(apsis, run):
         job = None
 
     # Load all outputs.
-    output = {
-        apsis.output.get_output(run.run_id, oi)
+    outputs = {
+        oi: apsis.outputs.get_output(run.run_id, oi)
         for oi in apsis.outputs.get_metadata(run.run_id)
     }
 
@@ -50,7 +50,7 @@ def snapshot_run(apsis, run):
         conds       =run.conds,
         program     =run.program,
         meta        =run.meta.copy(),
-        output      =output,
+        outputs     =outputs,
     )
 
 

--- a/test/int/action/jobs/with snapshot.yaml
+++ b/test/int/action/jobs/with snapshot.yaml
@@ -1,0 +1,9 @@
+program:
+  type: shell
+  command: "echo 'Hello, world!'"
+
+action:
+  type: apsis.actions.test.LogAction
+  condition:
+    states: success
+

--- a/test/int/action/test_basic_action.py
+++ b/test/int/action/test_basic_action.py
@@ -1,0 +1,34 @@
+from   contextlib import closing
+from   pathlib import Path
+import pytest
+
+from   instance import ApsisInstance
+
+#-------------------------------------------------------------------------------
+
+job_dir = Path(__file__).absolute().parent / "jobs"
+
+@pytest.fixture(scope="function")
+def inst():
+    with closing(ApsisInstance(job_dir=job_dir)) as inst:
+        inst.create_db()
+        inst.write_cfg()
+        inst.start_serve()
+        inst.wait_for_serve()
+        yield inst
+
+
+def test_run_action(inst):
+    run_id = inst.client.schedule("with snapshot", {})["run_id"]
+    inst.wait_run(run_id)
+    log = inst.get_log_lines()
+
+    # There should be a log line with the run ID.
+    token = f"run ID: {run_id}"
+    assert any( token in l for l in log )
+
+    # There should be a log line with the output.
+    assert any( "output: Hello, world!" in l for l in log )
+
+
+

--- a/test/int/instance.py
+++ b/test/int/instance.py
@@ -103,6 +103,11 @@ class ApsisInstance:
             yield iter(file)
 
 
+    def get_log_lines(self):
+        with self.get_log() as lines:
+            return tuple(lines)
+
+
     def stop_serve(self):
         assert self.srv_proc is not None
         self.srv_proc.send_signal(signal.SIGTERM)


### PR DESCRIPTION
Concrete action types should now inherit `BaseAction` rather than `Action`.  Each action must carry a condition.

Thread actions still implement from `ThreadAction`.
