### PR TITLE
Close fds when daemonizing.

### DIFF
--- a/python/apsis/agent/main.py
+++ b/python/apsis/agent/main.py
@@ -212,7 +212,10 @@ def main():
         ssl_context.load_cert_chain(SSL_CERT, keyfile=SSL_KEY)
 
         if not args.no_daemon:
-            daemonize(state_dir / "log")
+            daemonize(
+                state_dir / "log",
+                keep_fds=[pid_file.file.fileno(), sock.fileno()]
+            )
 
         logging.info(f"pid={os.getpid()}")
         uid = pwd.getpwuid(os.getuid())
@@ -222,10 +225,11 @@ def main():
         # FIXME: auto_reload added to sanic after 0.7.
         logging.info("running app")
         app.run(
-            sock    =sock,
-            ssl     =ssl_context,
+            sock        =sock,
+            ssl         =ssl_context,
             # FIXME: Debug seems to be completely broken?
-            # debug   =args.debug,
+            # debug     =args.debug,
+            auto_reload =False,
         )
 
     else:

--- a/test/unit/test_program_noop.py
+++ b/test/unit/test_program_noop.py
@@ -15,8 +15,8 @@ async def test_duration():
     prog = apsis.program.Program.from_jso(JSO)
     start = time.monotonic()
     running, coro = await prog.start("testrun", cfg={})
-    result = await coro
+    _ = await coro
     elapsed = time.monotonic() - start
-    assert elapsed > 0.75
+    assert elapsed > 0.7
 
 


### PR DESCRIPTION
When daemonizing, close all fds except those we know we need.
