### PR TITLE
Poll the run log once per minute.

### DIFF
--- a/vue/src/components/RunLog.vue
+++ b/vue/src/components/RunLog.vue
@@ -31,6 +31,10 @@ export default {
 
   created() {
     this.load()
+    // FIXME: Instead of reloading periodically, push changes over the
+    // websocket protocol.  Do not set this interval too short, to avoid
+    // loading the backend.
+    setInterval(this.load, 60000)
   },
 
   methods: {


### PR DESCRIPTION
For #305.  This is completely a temporary fix; pushing run log updates from the backend to the web UI via the websocket is the right way to do it, but will require some work.
