### PR TITLE
Feature/gh316

### DIFF
--- a/docs/jobs.rst
+++ b/docs/jobs.rst
@@ -160,6 +160,40 @@ given state.  Specify the job ID of the dependency, and any arguments.
 The arguments are template-expanded.  If the dependency job shares a param with
 the dependent job, it may be omitted; the same arg is used.
 
+By default, the dependency causes the run to wait until a matching **success**
+run arises.  You can specify another target state or set of states:
+
+.. code:: yaml
+
+    condition:
+        type: dependency
+        job_id: "previous job"
+        args:
+            label: foobar
+        states: ["success", "failure"]
+
+This condition does not actually create the dependecy run.  You must create that
+run elsewhere, usually by scheduling it.  If the run doesn't exist at all, the
+dependency condition will wait until `waiting.max_time` elapses, and then
+transition the run to **error**.
+
+To check that a corresponding dependency run exists at all, using set `exist` to
+true.  With this, the condition transitions the run to **error** _immediately_
+if the run does not exist, or if it has completed unsuccessfully.  If a run
+exists that may still transition to **success**, the condition waits as usual.
+
+.. code:: yaml
+
+    condition:
+        type: dependency
+        job_id: "previous job"
+        args:
+            label: foobar
+        exist: true
+
+Instead of true, you may provide a set of states in which the run must exist.
+The default is state from which one of the target states is reachable.
+
 
 Skipping Duplicates
 '''''''''''''''''''

--- a/python/apsis/cond/dependency.py
+++ b/python/apsis/cond/dependency.py
@@ -1,7 +1,8 @@
 import logging
 
 from   apsis.lib.py import format_ctor, iterize
-from   apsis.runs import Run, Instance, get_bind_args
+from   apsis.runs import Instance, get_bind_args
+from   apsis.states import State
 from   .base import RunStoreCondition, _bind
 
 log = logging.getLogger(__name__)
@@ -13,9 +14,14 @@ class Dependency(RunStoreCondition):
     True if a run exists and is in a given state.
     """
 
-    def __init__(self, job_id, args={}, states={Run.STATE.success}):
+    DEFAULT_STATE = { State.success }
+
+    def __init__(
+            self, job_id, args={},
+            states=DEFAULT_STATE,
+    ):
         states = frozenset(iterize(states))
-        assert all( isinstance(s, Run.STATE) for s in states )
+        assert all( isinstance(s, State) for s in states )
 
         self.job_id = job_id
         self.args = args
@@ -43,7 +49,7 @@ class Dependency(RunStoreCondition):
 
     @classmethod
     def from_jso(cls, jso):
-        states = { Run.STATE[s] for s in iterize(jso.pop("states", "success")) }
+        states = { State[s] for s in iterize(jso.pop("states", "success")) }
         return cls(
             jso.pop("job_id"),
             jso.pop("args", {}),

--- a/python/apsis/cond/dependency.py
+++ b/python/apsis/cond/dependency.py
@@ -2,7 +2,7 @@ import logging
 
 from   apsis.lib.py import format_ctor, iterize
 from   apsis.runs import Instance, get_bind_args
-from   apsis.states import State
+from   apsis.states import State, reachable
 from   .base import RunStoreCondition, _bind
 
 log = logging.getLogger(__name__)
@@ -11,31 +11,46 @@ log = logging.getLogger(__name__)
 
 class Dependency(RunStoreCondition):
     """
-    True if a run exists and is in a given state.
+    Waits for a run in a given state or states.
     """
 
     DEFAULT_STATE = { State.success }
 
     def __init__(
             self, job_id, args={},
-            states=DEFAULT_STATE,
+            *,
+            states  =DEFAULT_STATE,
+            exist   =None,
     ):
         states = frozenset(iterize(states))
         assert all( isinstance(s, State) for s in states )
+        if exist is not None:
+            assert all( isinstance(s, State) for s in exist )
+            assert len(set(exist) - set(states)) == 0
 
         self.job_id = job_id
-        self.args = args
+        self.args   = args
         self.states = states
+        self.exist  = exist
 
 
     def __repr__(self):
-        return format_ctor(self, self.job_id, self.args, states=self.states)
+        return format_ctor(
+            self,
+            self.job_id, self.args,
+            states  =self.states,
+            exist   =self.exist,
+        )
 
 
     def __str__(self):
         inst = Instance(self.job_id, self.args)
         states = "|".join( s.name for s in self.states )
-        return f"dependency {inst} is {states}"
+        exist = (
+            "" if self.exist is None
+            else ", must exist as " + "|".join( s.name for s in self.exist )
+        )
+        return f"dependency {inst} is {states}{exist}"
 
 
     def to_jso(self):
@@ -44,16 +59,27 @@ class Dependency(RunStoreCondition):
             "job_id": self.job_id,
             "args"  : self.args,
             "states": [ s.name for s in self.states ],
+            "exist" : 
+                None if self.exist is None
+                else [ s.name for s in self.exist ],
         }
 
 
     @classmethod
     def from_jso(cls, jso):
         states = { State[s] for s in iterize(jso.pop("states", "success")) }
+        exist = jso.pop("exist", None)
+        if exist is True:
+            # Require the existence of a run in any state from which one of the
+            # target states is reachable.
+            exist = { s for s in State if reachable(s) & states }
+        elif exist is not None:
+            exist = { State[s] for s in iterize(exist) }
         return cls(
             jso.pop("job_id"),
             jso.pop("args", {}),
-            states,
+            states  =states,
+            exist   =exist,
         )
 
 
@@ -61,22 +87,48 @@ class Dependency(RunStoreCondition):
         job = jobs[self.job_id]
         bind_args = get_bind_args(run)
         args = _bind(job, self.args, run.inst.args, bind_args)
-        return type(self)(self.job_id, args, self.states)
+        return type(self)(
+            self.job_id, args,
+            states  =self.states,
+            exist   =self.exist,
+        )
 
 
     async def wait(self, run_store):
         with run_store.query_live(
-            job_id=self.job_id,
-            args=self.args,
-            state=self.states,
+                job_id  =self.job_id,
+                args    =self.args,
         ) as queue:
-            _, (run, *_) = await queue.get()
-        assert run.inst.job_id == self.job_id
-        assert all( run.inst.args[k] == v for k, v in self.args.items() )
-        assert run.state in self.states
+            while True:
+                if self.exist is not None:
+                    # First check whether a valid dependency run exists, in one
+                    # of the exist states.
+                    exist_runs = run_store.query(
+                        job_id  =self.job_id,
+                        args    =self.args,
+                        state   =self.exist,
+                    )
+                    if next(exist_runs, None) is None:
+                        # No dependency run exists in a valid starting state.
+                        inst = Instance(self.job_id, self.args)
+                        exst = "|".join(self.exist)
+                        return self.Transaction(
+                            State.error,
+                            f"no dependency {inst} in {exst}"
+                        )
 
-        log.debug(f"dependency satisfied: {run}")
-        return True
+                # Wait for something to happen.  
+                _, runs = await queue.get()
+                # Is there a run in any of the target states?
+                runs = ( r for r in runs if r.state in self.states )
+                run = next(runs, None)
+                if run is not None:
+                    assert run.inst.job_id == self.job_id
+                    assert all( run.inst.args[k] == v for k, v in self.args.items() )
+                    assert run.state in self.states
+
+                    log.debug(f"dependency satisfied: {run}")
+                    return True
 
 
 

--- a/python/apsis/lib/py.py
+++ b/python/apsis/lib/py.py
@@ -68,6 +68,7 @@ def or_none(fn):
 nstr    = or_none(str)
 nint    = or_none(int)
 nfloat  = or_none(float)
+nbool   = or_none(bool)
 
 
 def is_seq(obj):

--- a/python/apsis/states.py
+++ b/python/apsis/states.py
@@ -47,3 +47,23 @@ def states_to_jso(states):
     )
 
 
+def reachable(state):
+    """
+    Returns the set of states reachable from `state` by zero or more
+    transitions.
+    """
+    reachable = {state}
+    while True:
+        # Find immediate successors.
+        succ = {
+            s
+            for s, pred in TRANSITIONS.items()
+            if any( r in pred for r in reachable )
+        }
+        # If there are no new successors, stop.
+        if len(succ - reachable) == 0:
+            return reachable
+        else:
+            reachable |= succ
+
+

--- a/test/int/cond/jobs/exist fail.yaml
+++ b/test/int/cond/jobs/exist fail.yaml
@@ -1,0 +1,13 @@
+params: [date, color]
+
+program:
+  type: no-op
+  duration: 0
+
+condition:
+  - type: dependency
+    job_id: fail
+    args:
+      flavor: vanilla
+    exist: true
+

--- a/test/int/cond/jobs/exist slow.yaml
+++ b/test/int/cond/jobs/exist slow.yaml
@@ -1,0 +1,19 @@
+params: [date, color]
+
+program:
+  type: no-op
+  duration: 0
+
+condition:
+  - type: dependency
+    job_id: slow
+    args:
+      flavor: vanilla
+    exist: true
+
+  - type: dependency
+    job_id: slow
+    args:
+      flavor: chocolate
+    exist: true
+

--- a/test/int/cond/jobs/exist.yaml
+++ b/test/int/cond/jobs/exist.yaml
@@ -1,0 +1,19 @@
+params: [date, color]
+
+program:
+  type: no-op
+  duration: 0
+
+condition:
+  - type: dependency
+    job_id: dependency
+    args:
+      flavor: vanilla
+    exist: true
+
+  - type: dependency
+    job_id: dependency
+    args:
+      flavor: chocolate
+    exist: true
+

--- a/test/int/cond/jobs/fail.yaml
+++ b/test/int/cond/jobs/fail.yaml
@@ -1,0 +1,7 @@
+params: [date]
+
+program:
+  type: no-op
+  duration: 0.25
+  success: false
+

--- a/test/int/cond/jobs/slow.yaml
+++ b/test/int/cond/jobs/slow.yaml
@@ -1,0 +1,6 @@
+params: [date, flavor]
+
+program:
+  type: no-op
+  duration: 1
+

--- a/test/int/cond/test_cond.py
+++ b/test/int/cond/test_cond.py
@@ -5,7 +5,6 @@ Tests conditions.
 from   contextlib import closing
 from   pathlib import Path
 import pytest
-import random
 import time
 
 from   instance import ApsisInstance
@@ -27,50 +26,6 @@ def inst():
 @pytest.fixture
 def client(inst, scope="function"):
     return inst.client
-
-
-def test_args_match(inst):
-    """
-    Tests that args in dependencies are processed correctly.
-    """
-    client = inst.client
-
-    res = client.schedule("dependent", {"date": "2022-11-01", "color": "red"})
-    run_id = res["run_id"]
-
-    # This job depends on dependency(date=2022-11-01 flavor=vanilla) and
-    # dependency(date=2022-11-01 flavor=chocolate).
-    res = client.get_run(run_id)
-    assert res["state"] == "waiting"
-
-    # Run the first of the dependencies.
-    res = client.schedule("dependency", {"date": "2022-11-01", "flavor": "vanilla"})
-
-    # One dependency satisfied, but not the other one.
-    res = client.get_run(run_id)
-    assert res["state"] == "waiting"
-
-    # This is not a dependency, as the date is wrong.
-    res = client.schedule("dependency", {"date": "2022-12-25", "flavor": "chocolate"})
-
-    # One dependency satisfied, but not the other one.
-    res = client.get_run(run_id)
-    assert res["state"] == "waiting"
-
-    # This is just the first dependency, run again.
-    res = client.schedule("dependency", {"date": "2022-11-01", "flavor": "vanilla"})
-
-    # One dependency satisfied, but not the other one.
-    res = client.get_run(run_id)
-    assert res["state"] == "waiting"
-
-    # Now run the second dependency.
-    res = client.schedule("dependency", {"date": "2022-11-01", "flavor": "chocolate"})
-    inst.wait_run(res["run_id"])
-
-    # Both are satisfied.
-    res = inst.wait_run(run_id)
-    assert res["state"] == "success"
 
 
 def test_args_max_waiting():
@@ -194,62 +149,6 @@ def test_to_error(client):
     red3 = res["run_id"]
     res = client.get_run(red3)
     assert res["state"] == "running"
-
-
-@pytest.mark.parametrize("direction", ["forward", "backward", "shuffle"])
-def test_many_deps(inst, direction):
-    """
-    Tests a job with a large number of conditions.
-
-    :param direction:
-      Order in which the dependencies are run, relative to specified.
-    """
-    client = inst.client
-
-    # Create a job with many dependencies.
-    vals = [ format(i, "03d") for i in range(200) ]
-    job = {
-        "program": {"type": "no-op"},
-        "condition": [
-            {
-                "type": "dependency",
-                "job_id": "many dep",
-                "args": {"val": v},
-            }
-            for v in vals
-        ]
-    }
-
-    res = client.schedule_adhoc("now", job)
-    run_id = res["run_id"]
-    assert res["state"] == "waiting"
-
-    # Run the dependencies, in order depending on `direction`.
-    match direction:
-        case "forward":
-            pass
-        case "backward":
-            vals = vals[:: -1]
-        case "shuffle":
-            random.shuffle(vals)
-        case _:
-            assert False
-
-    # All dependencies but one.
-    for v in vals[: -1]:
-        client.schedule("many dep", {"val": v})
-
-    time.sleep(1)
-    # The run is still waiting.
-    res = client.get_run(run_id)
-    assert res["state"] == "waiting"
-
-    # Schedule the last dependency.
-    client.schedule("many dep", {"val": vals[-1]})
-
-    # Now the run can continue.s
-    res = inst.wait_run(run_id)
-    assert res["state"] == "success"
 
 
 def test_thread_cond(inst):

--- a/test/int/cond/test_dep.py
+++ b/test/int/cond/test_dep.py
@@ -1,0 +1,131 @@
+"""
+Tests dependency conditions.
+"""
+
+from   contextlib import closing
+from   pathlib import Path
+import pytest
+import random
+import time
+
+from   instance import ApsisInstance
+
+#-------------------------------------------------------------------------------
+
+job_dir = Path(__file__).absolute().parent / "jobs"
+
+@pytest.fixture(scope="function")
+def inst():
+    with closing(ApsisInstance(job_dir=job_dir)) as inst:
+        inst.create_db()
+        inst.write_cfg()
+        inst.start_serve()
+        inst.wait_for_serve()
+        yield inst
+
+
+@pytest.fixture
+def client(inst, scope="function"):
+    return inst.client
+
+
+def test_args_match(inst):
+    """
+    Tests that args in dependencies are processed correctly.
+    """
+    client = inst.client
+
+    res = client.schedule("dependent", {"date": "2022-11-01", "color": "red"})
+    run_id = res["run_id"]
+
+    # This job depends on dependency(date=2022-11-01 flavor=vanilla) and
+    # dependency(date=2022-11-01 flavor=chocolate).
+    res = client.get_run(run_id)
+    assert res["state"] == "waiting"
+
+    # Run the first of the dependencies.
+    res = client.schedule("dependency", {"date": "2022-11-01", "flavor": "vanilla"})
+
+    # One dependency satisfied, but not the other one.
+    res = client.get_run(run_id)
+    assert res["state"] == "waiting"
+
+    # This is not a dependency, as the date is wrong.
+    res = client.schedule("dependency", {"date": "2022-12-25", "flavor": "chocolate"})
+
+    # One dependency satisfied, but not the other one.
+    res = client.get_run(run_id)
+    assert res["state"] == "waiting"
+
+    # This is just the first dependency, run again.
+    res = client.schedule("dependency", {"date": "2022-11-01", "flavor": "vanilla"})
+
+    # One dependency satisfied, but not the other one.
+    res = client.get_run(run_id)
+    assert res["state"] == "waiting"
+
+    # Now run the second dependency.
+    res = client.schedule("dependency", {"date": "2022-11-01", "flavor": "chocolate"})
+    inst.wait_run(res["run_id"])
+
+    # Both are satisfied.
+    res = inst.wait_run(run_id)
+    assert res["state"] == "success"
+
+
+@pytest.mark.parametrize("direction", ["forward", "backward", "shuffle"])
+def test_many_deps(inst, direction):
+    """
+    Tests a job with a large number of conditions.
+
+    :param direction:
+      Order in which the dependencies are run, relative to specified.
+    """
+    client = inst.client
+
+    # Create a job with many dependencies.
+    vals = [ format(i, "03d") for i in range(200) ]
+    job = {
+        "program": {"type": "no-op"},
+        "condition": [
+            {
+                "type": "dependency",
+                "job_id": "many dep",
+                "args": {"val": v},
+            }
+            for v in vals
+        ]
+    }
+
+    res = client.schedule_adhoc("now", job)
+    run_id = res["run_id"]
+    assert res["state"] == "waiting"
+
+    # Run the dependencies, in order depending on `direction`.
+    match direction:
+        case "forward":
+            pass
+        case "backward":
+            vals = vals[:: -1]
+        case "shuffle":
+            random.shuffle(vals)
+        case _:
+            assert False
+
+    # All dependencies but one.
+    for v in vals[: -1]:
+        client.schedule("many dep", {"val": v})
+
+    time.sleep(1)
+    # The run is still waiting.
+    res = client.get_run(run_id)
+    assert res["state"] == "waiting"
+
+    # Schedule the last dependency.
+    client.schedule("many dep", {"val": vals[-1]})
+
+    # Now the run can continue.s
+    res = inst.wait_run(run_id)
+    assert res["state"] == "success"
+
+

--- a/test/int/cond/test_dep.py
+++ b/test/int/cond/test_dep.py
@@ -129,3 +129,106 @@ def test_many_deps(inst, direction):
     assert res["state"] == "success"
 
 
+def test_exist(inst):
+    client = inst.client
+    date = "2023-12-27"
+
+    # Schedule the dependent without any dependency; this results in error
+    # because depedency(flavor=vanilla) and dependency(flavor=chocolate) must
+    # exist.
+    res = client.schedule("exist", {"date": date, "color": "red"})
+    run_id = res["run_id"]
+    res = inst.wait_run(run_id)
+    assert res["state"] == "error"
+
+    # Schedule the first dependency.
+    res = client.schedule("dependency", {"date": date, "flavor": "chocolate"})
+    inst.wait_run(res["run_id"])
+
+    # One dependency isn't enough.
+    res = client.schedule("exist", {"date": date, "color": "red"})
+    run_id = res["run_id"]
+    res = inst.wait_run(run_id)
+    assert res["state"] == "error"
+
+    # Schedule the second dependency.
+    res = client.schedule("dependency", {"date": date, "flavor": "vanilla"})
+    inst.wait_run(res["run_id"])
+
+    # Both dependencies should exist, so we can proceed.
+    res = client.schedule("exist", {"date": date, "color": "red"})
+    run_id = res["run_id"]
+    res = inst.wait_run(run_id)
+    assert res["state"] == "success"
+
+
+def test_exist_slow(inst):
+    client = inst.client
+    date = "2023-12-27"
+
+    # Schedule the dependent without any dependency; this results in error
+    # because depedency(flavor=vanilla) and dependency(flavor=chocolate) must
+    # exist.
+    res = client.schedule("exist slow", {"date": date, "color": "red"})
+    run_id = res["run_id"]
+    res = inst.wait_run(run_id)
+    assert res["state"] == "error"
+
+    # Schedule the first dependency.
+    res = client.schedule("slow", {"date": date, "flavor": "chocolate"})
+
+    # Try the dependent again.  The dependency, slow(flavor=chocolate), isn't
+    # done yet, but that's OK.
+    res = client.schedule("exist slow", {"date": date, "color": "red"})
+    run_id = res["run_id"]
+    res = inst.wait_run(run_id)
+    assert res["state"] == "error"
+
+    # Schedule the second dependency.
+    res = client.schedule("slow", {"date": date, "flavor": "vanilla"})
+
+    # Both dependencies exist, whether or not they are successful, so OK.
+    res = client.schedule("exist slow", {"date": date, "color": "red"})
+    run_id = res["run_id"]
+    res = inst.wait_run(run_id)
+    assert res["state"] == "success"
+
+
+def test_exist_fail(inst):
+    client = inst.client
+    date = "2023-12-27"
+
+    # Schedule the dependent without any dependency; this results in error
+    # because depedency(flavor=vanilla) and dependency(flavor=chocolate) must
+    # exist.
+    res = client.schedule("exist fail", {"date": date, "color": "red"})
+    run_id = res["run_id"]
+    res = inst.wait_run(run_id)
+    assert res["state"] == "error"
+
+    # Schedule the dependency.
+    dep_run_id = client.schedule("fail", {"date": date})["run_id"]
+
+    # Now schedule the dependent should work.  The dependency is running, so
+    # this should enter waiting.
+    res = client.schedule("exist fail", {"date": date, "color": "red"})
+    run_id = res["run_id"]
+    time.sleep(0.1)
+    res = client.get_run(run_id)
+    assert res["state"] == "waiting"
+
+    # Wait for the dependency to fail.
+    res = inst.wait_run(dep_run_id)
+    assert res["state"] == "failure"
+
+    # The dependent should error too.
+    res = inst.wait_run(run_id)
+    assert res["state"] == "error"
+
+    # Now the dependent should no longer work; the dependency is running.
+    res = client.schedule("exist fail", {"date": date, "color": "red"})
+    run_id = res["run_id"]
+    res = inst.wait_run(run_id)
+    assert res["state"] == "error"
+
+

--- a/test/unit/test_state.py
+++ b/test/unit/test_state.py
@@ -1,0 +1,26 @@
+from   apsis.states import State, reachable
+
+#-------------------------------------------------------------------------------
+
+def test_reachable():
+    states = set(State)
+    assert reachable(State.new) == states
+    states -= {State.new}
+
+    assert reachable(State.scheduled) == states
+    states -= {State.scheduled}
+
+    assert reachable(State.waiting) == states
+    states -= {State.waiting, State.skipped}
+
+    assert reachable(State.starting) == states
+    states -= {State.starting}
+
+    assert reachable(State.running) == states
+
+    assert reachable(State.success) == {State.success}
+    assert reachable(State.failure) == {State.failure}
+    assert reachable(State.skipped) == {State.skipped, State.error}
+    assert reachable(State.error)   == {State.error}
+
+


### PR DESCRIPTION
Resolves #316 

This adds an `exist` option to the dependency condition.  If true, the condition induces an error if no dependency run exists in a state from which the target state (usually _success_) is reachable.  This is checked continuously.

```yaml
condition:
  type: dependency
  job_id: predecessor
  exist: true
```
