### PR TITLE
Fix/skip duplicate race

### DIFF
--- a/python/apsis/cond/base.py
+++ b/python/apsis/cond/base.py
@@ -128,6 +128,29 @@ class RunStoreCondition(Condition):
         start.
 
         :return:
+          `True` if the run is ready, or `Transition` to cause the run to
+          transition to a new state.
+        """
+        return True
+
+
+
+class NonmonotonicRunStoreCondition(RunStoreCondition):
+    """
+    A `RunStoreCondition` where the condition is not monotonic, i.e. once
+    satisfied, it may later no longer be satisfied.
+
+    The waiting logic invokes condition's (synchronous) `check()` method after
+    `wait()` has succeeded, to confirm that condition is still met before
+    immediatley continuing to the next condition.
+    """
+
+    def check(self, run_store):
+        """
+        Checks synchronously if run-based conditions have been met.  The
+        semantics should match those of `wait()`.
+
+        :return:
           `True` if the run is ready, `False` otherwise, or `Transition` to
           cause the run to transition to a new state.
         """

--- a/python/apsis/cond/max_running.py
+++ b/python/apsis/cond/max_running.py
@@ -2,7 +2,7 @@ import logging
 
 from   apsis.lib.py import format_ctor
 from   apsis.runs import Instance, Run, get_bind_args, template_expand
-from   .base import Condition, RunStoreCondition
+from   .base import Condition, NonmonotonicRunStoreCondition
 
 log = logging.getLogger(__name__)
 
@@ -70,7 +70,7 @@ class MaxRunning(Condition):
 
 #-------------------------------------------------------------------------------
 
-class BoundMaxRunning(RunStoreCondition):
+class BoundMaxRunning(NonmonotonicRunStoreCondition):
 
     def __init__(self, count, job_id, args):
         self.__count    = int(count)
@@ -125,11 +125,10 @@ class BoundMaxRunning(RunStoreCondition):
                 job_id  =self.__job_id,
                 args    =self.__args,
         ) as queue:
-            while not self.check(run_store):
+            while (result := self.check(run_store)) is False:
                 # Wait until a relevant run transitions, then check again.
                 _ = await queue.get()
-
-        return True
+        return result
 
 
 

--- a/python/apsis/cond/max_running.py
+++ b/python/apsis/cond/max_running.py
@@ -2,13 +2,13 @@ import logging
 
 from   apsis.lib.py import format_ctor
 from   apsis.runs import Instance, Run, get_bind_args, template_expand
-from   .base import RunStoreCondition
+from   .base import Condition, RunStoreCondition
 
 log = logging.getLogger(__name__)
 
 #-------------------------------------------------------------------------------
 
-class MaxRunning(RunStoreCondition):
+class MaxRunning(Condition):
     """
     Limits simultaneous running jobs.
 
@@ -24,9 +24,9 @@ class MaxRunning(RunStoreCondition):
         :param args:
           Args to match.  If none, the bound to the args of the owning instance.
         """
-        self.__count = count
-        self.__job_id = job_id
-        self.__args = args
+        self.__count    = count
+        self.__job_id   = job_id
+        self.__args     = args
 
 
     def __repr__(self):
@@ -35,13 +35,7 @@ class MaxRunning(RunStoreCondition):
 
 
     def __str__(self):
-        if self.__job_id is None or self.__args is None:
-            # Not yet bound.
-            return f"fewer than {self.__count} runs running"
-        else:
-            # Bound.
-            inst = Instance(self.__job_id, self.__args)
-            return f"fewer than {self.__count} runs of {inst} running"
+        return f"fewer than {self.__count} runs running"
 
 
     def to_jso(self):
@@ -70,11 +64,49 @@ class MaxRunning(RunStoreCondition):
         # inst.args, and bind to job args.
         if self.__args is not None:
             raise NotImplementedError()
-        return type(self)(count, job_id, run.inst.args)
+        return BoundMaxRunning(count, job_id, run.inst.args)
+
+
+
+#-------------------------------------------------------------------------------
+
+class BoundMaxRunning(RunStoreCondition):
+
+    def __init__(self, count, job_id, args):
+        self.__count    = int(count)
+        self.__job_id   = job_id
+        self.__args     = args
+
+
+    def __repr__(self):
+        return format_ctor(
+            self, self.__count, job_id=self.__job_id, args=self.__args)
+
+
+    def __str__(self):
+        inst = Instance(self.__job_id, self.__args)
+        return f"fewer than {self.__count} runs of {inst} running"
+
+
+    def to_jso(self):
+        return {
+            **super().to_jso(),
+            "count" : self.__count,
+            "job_id": self.__job_id,
+             "args" : self.__args,
+        }
+
+
+    @classmethod
+    def from_jso(cls, jso):
+        return cls(
+            jso.pop("count"),
+            jso.pop("job_id"),
+            jso.pop("args"),
+        )
 
 
     def check(self, run_store):
-        max_count = int(self.__count)
         # Count running jobs.
         _, running = run_store.query(
             job_id  =self.__job_id,
@@ -83,7 +115,7 @@ class MaxRunning(RunStoreCondition):
         )
         count = len(list(running))
         log.debug(f"found {count} running")
-        return count < max_count
+        return count < self.__count
 
 
     async def wait(self, run_store):

--- a/test/int/jobs/dep.yaml
+++ b/test/int/jobs/dep.yaml
@@ -1,0 +1,3 @@
+program:
+  type: no-op
+

--- a/test/int/jobs/skip duplicate race.yaml
+++ b/test/int/jobs/skip duplicate race.yaml
@@ -1,0 +1,8 @@
+condition:
+  - type: dependency
+    job_id: dep
+  - type: skip_duplicate
+
+program:
+  type: no-op
+


### PR DESCRIPTION
Generalizes the #304 fix to `NonmonotonicRunStoreCondition` subtypes, and applies it to `SkipDuplicate`.
