### PR TITLE
Add Litestream Apsis db replica test

### DIFF
--- a/test/int/litestream/jobs/job1.yaml
+++ b/test/int/litestream/jobs/job1.yaml
@@ -1,2 +1,3 @@
 program:
-  type: no-op
+  type: shell
+  command: /usr/bin/sleep 10

--- a/test/int/litestream/jobs/job1.yaml
+++ b/test/int/litestream/jobs/job1.yaml
@@ -1,0 +1,2 @@
+program:
+  type: no-op

--- a/test/int/litestream/test_replica.py
+++ b/test/int/litestream/test_replica.py
@@ -98,7 +98,6 @@ def test_replica():
         assert any(restored_db_name in l for l in log)
 
         # check runs data is accurate in the restored db
-        client = inst.client
         for id, state in zip(run_ids, expected_states):
             assert client.get_run(id)["state"] == state
 
@@ -166,7 +165,6 @@ def test_replica_killing_apsis_and_litestream():
         assert any(restored_db_name in l for l in log)
 
         # check the run is still in the running state after reconnecting to the new Apsis instance
-        client = inst.client
         assert client.get_run(run_id)["state"] == "running"
 
         # check run eventually completes successfully

--- a/test/int/litestream/test_replica.py
+++ b/test/int/litestream/test_replica.py
@@ -15,16 +15,7 @@ JOB_DIR = Path(__file__).parent / "jobs"
 
 
 def is_litestream_available():
-    try:
-        subprocess.run(
-            ["litestream", "version"],
-            check=True,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        return False
-    return True
+    return True if shutil.which("litestream") else False
 
 
 def start_litestream(db_path, replica_path):

--- a/test/int/litestream/test_replica.py
+++ b/test/int/litestream/test_replica.py
@@ -72,6 +72,7 @@ def test_replica():
             for state in expected_states:
                 run_id = client.schedule("job1", {})["run_id"]
                 inst.wait_run(run_id)
+                assert client.get_run(run_id)["state"] == "success"
                 if state != "success":
                     client.mark(run_id, state)
                 run_ids.append(run_id)

--- a/test/int/litestream/test_replica.py
+++ b/test/int/litestream/test_replica.py
@@ -4,6 +4,7 @@ import subprocess
 import os
 import signal
 from time import sleep
+import pytest
 
 from instance import ApsisService
 
@@ -11,6 +12,19 @@ from instance import ApsisService
 JOB_DIR = Path(__file__).parent / "jobs"
 
 # -------------------------------------------------------------------------------
+
+
+def is_litestream_available():
+    try:
+        subprocess.run(
+            ["litestream", "version"],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False
+    return True
 
 
 def start_litestream(db_path, replica_path):
@@ -38,6 +52,7 @@ def restore_litestream_db(restored_db_path, litestream_replica_path):
     )
 
 
+@pytest.mark.skipif(not is_litestream_available(), reason="Litestream is not available")
 def test_replica():
     """
     Tests Litestream replica of the SQLite db.
@@ -110,6 +125,7 @@ def test_replica():
         inst.stop_serve()
 
 
+@pytest.mark.skipif(not is_litestream_available(), reason="Litestream is not available")
 def test_replica_killing_apsis_and_litestream():
     """
     Similar to `test_replica`, but here:

--- a/test/int/litestream/test_replica.py
+++ b/test/int/litestream/test_replica.py
@@ -1,0 +1,94 @@
+from pathlib import Path
+from contextlib import closing
+import subprocess
+
+from instance import ApsisService
+
+
+JOB_DIR = Path(__file__).parent / "jobs"
+
+# -------------------------------------------------------------------------------
+
+
+def test_replica():
+    """
+    Tests Litestream replica of the SQLite db.
+
+    Steps:
+    - start Litestream process;
+    - start Apsis and populate its db with some data;
+    - stop Apsis (i.e. simulating a db failure) and Litestream processes;
+    - restore db from Litestream replica;
+    - check that Apsis works fine with the restored db and that data initially written to the original db are there.
+    """
+
+    with closing(ApsisService(job_dir=JOB_DIR)) as inst:
+
+        inst.create_db()
+        inst.write_cfg()
+
+        # start Litestream replica
+        litestream_replica_path = inst.tmp_dir / "litestream_replica.db"
+        with subprocess.Popen(
+            [
+                "litestream",
+                "replicate",
+                inst.db_path,
+                f"file://{str(litestream_replica_path)}",
+            ]
+        ) as litestream_process:
+
+            inst.start_serve()
+            inst.wait_for_serve()
+
+            # populate apsis db with some data
+            client = inst.client
+            run_ids = []
+            expected_states = ["success", "failure", "error", "skipped"]
+            for state in expected_states:
+                run_id = client.schedule("job1", {})["run_id"]
+                inst.wait_run(run_id)
+                if state != "success":
+                    client.mark(run_id, state)
+                run_ids.append(run_id)
+
+            # stop Apsis and Litestream
+            inst.stop_serve()
+            litestream_process.terminate()
+
+        # restore the db from the replica
+        restored_db_name = "restored.db"
+        restored_db_path = inst.tmp_dir / restored_db_name
+        subprocess.run(
+            [
+                "litestream",
+                "restore",
+                "-o",
+                str(restored_db_path),
+                f"file://{str(litestream_replica_path)}",
+            ],
+            check=True,
+        )
+
+        # rewrite the config to use restored db
+        inst.db_path = restored_db_path
+        inst.write_cfg()
+
+        # restart Apsis
+        inst.start_serve()
+        inst.wait_for_serve()
+
+        log = inst.get_log_lines()
+        assert any(restored_db_name in l for l in log)
+
+        # check runs data is accurate in the restored db
+        client = inst.client
+        for id, state in zip(run_ids, expected_states):
+            assert client.get_run(id)["state"] == state
+
+        # run job again to verify the db is in a good state and Apsis can read/write it
+        new_run_id = client.schedule("job1", {})["run_id"]
+        inst.wait_run(new_run_id)
+        assert client.get_run(new_run_id)["state"] == "success"
+
+        inst.stop_serve()

--- a/test/int/litestream/test_replica.py
+++ b/test/int/litestream/test_replica.py
@@ -120,7 +120,6 @@ def test_replica_killing_apsis_and_litestream():
     - start Litestream process;
     - start Apsis and schedule a run;
     - kill Apsis and Litestream using SIGKILL signals;
-    - stop Litestream process gracefully through SIGTERM;
     - restore db from Litestream replica;
     - check that the run is still in running state using the restored db.
     """

--- a/test/int/litestream/test_replica.py
+++ b/test/int/litestream/test_replica.py
@@ -1,10 +1,11 @@
-from pathlib import Path
-from contextlib import closing
-import subprocess
+from   contextlib import closing
 import os
-import signal
-from time import sleep
+from   pathlib import Path
 import pytest
+import shutil
+import signal
+import subprocess
+from   time import sleep
 
 from instance import ApsisService
 

--- a/test/int/litestream/test_replica.py
+++ b/test/int/litestream/test_replica.py
@@ -15,7 +15,7 @@ JOB_DIR = Path(__file__).parent / "jobs"
 
 
 def is_litestream_available():
-    return True if shutil.which("litestream") else False
+    return shutil.which("litestream") is not None
 
 
 def start_litestream(db_path, replica_path):


### PR DESCRIPTION
Add test that mimics the situation where Apsis must be restarted using a db created from a Litestream replica.


