### PR TITLE
show dependencies and dependents in run view

### DIFF
--- a/python/apsis/cond/dependency.py
+++ b/python/apsis/cond/dependency.py
@@ -19,7 +19,7 @@ class Dependency(RunStoreCondition):
     Waits for a run in a given state or states.
     """
 
-    DEFAULT_STATE = { State.success }
+    DEFAULT_STATE = State.success
 
     def __init__(
             self, job_id, args={},
@@ -61,21 +61,22 @@ class Dependency(RunStoreCondition):
 
 
     def to_jso(self):
-        return {
+        jso = {
             **super().to_jso(),
             "job_id": self.job_id,
             "args"  : self.args,
-            "states": [ s.name for s in self.states ],
-            "exist" :
-                None if self.exist is None
-                else [ s.name for s in self.exist ],
         }
+        if self.states != {self.DEFAULT_STATE}:
+            jso["states"] = [ s.name for s in self.states ]
+        if self.exist is not None:
+            jso["exist"] = [ s.name for s in self.exist ]
+        return jso
 
 
     @classmethod
     def from_jso(cls, jso):
         with check_schema(jso) as pop:
-            states = pop("states", default="success")
+            states = pop("states", default=cls.DEFAULT_STATE.name)
             states = { State[s] for s in iterize(states) }
             exist = pop("exist", default=None)
             if exist is True:

--- a/python/apsis/lib/api.py
+++ b/python/apsis/lib/api.py
@@ -106,6 +106,8 @@ def job_to_jso(job):
 
 
 def run_to_summary_jso(run):
+    from apsis.cond.dependency import Dependency
+
     jso = run._summary_jso_cache
     if jso is not None:
         # Use the cached JSO.
@@ -121,6 +123,15 @@ def run_to_summary_jso(run):
     }
     if run.expected:
         jso["expected"] = run.expected
+
+    if run.conds is not None:
+        deps = [
+            [c.job_id, c.args]
+            for c in run.conds
+            if isinstance(c, Dependency)
+        ]
+        if len(deps) > 0:
+            jso["dependencies"] = deps
 
     run._summary_jso_cache = jso
     return jso

--- a/python/apsis/runs.py
+++ b/python/apsis/runs.py
@@ -372,7 +372,7 @@ class RunStore:
             r.run_id: r
             for r in self.__run_db.query(min_timestamp=min_timestamp)
         }
-        # Also keep a lookup of runs by job ID.
+        # Keep a lookup of runs by job ID.
         self.__runs_by_job = {}
         for run in self.__runs.values():
             self.__runs_by_job.setdefault(run.inst.job_id, set()).add(run)

--- a/python/apsis/service/client.py
+++ b/python/apsis/service/client.py
@@ -285,6 +285,10 @@ class Client:
         return self.__get("/api/v1/runs", run_id)["runs"][run_id]
 
 
+    def get_run_dependencies(self, run_id):
+        return self.__get("/api/v1/runs", run_id, "dependencies")[run_id]
+
+
     @asynccontextmanager
     async def get_run_updates(self, run_id, *, init=False):
         """

--- a/test/int/cond/test_dep.py
+++ b/test/int/cond/test_dep.py
@@ -400,6 +400,6 @@ def test_api_dependencies():
         deps = client.get_run_dependencies(run_id)
         assert len(deps) == 2
         assert deps[0]["run_ids"] == [dep_run_id1]
-        assert deps[1]["run_ids"] == [dep_run_id0, dep_run_id2]
+        assert set(deps[1]["run_ids"]) == {dep_run_id0, dep_run_id2}
 
 

--- a/test/manual/procstar/jobs/dep/job a.yaml
+++ b/test/manual/procstar/jobs/dep/job a.yaml
@@ -1,0 +1,5 @@
+params: [x]
+
+program:
+  type: no-op
+

--- a/test/manual/procstar/jobs/dep/job b.yaml
+++ b/test/manual/procstar/jobs/dep/job b.yaml
@@ -1,0 +1,5 @@
+params: [y]
+
+program:
+  type: no-op
+

--- a/test/manual/procstar/jobs/dep/job c.yaml
+++ b/test/manual/procstar/jobs/dep/job c.yaml
@@ -1,0 +1,11 @@
+params: [x, y]
+
+condition:
+- type: dependency
+  job_id: "dep/job a"
+- type: dependency
+  job_id: "dep/job b"
+
+program:
+  type: no-op
+

--- a/test/manual/procstar/jobs/dep/job d.yaml
+++ b/test/manual/procstar/jobs/dep/job d.yaml
@@ -1,0 +1,9 @@
+params: [x, y]
+
+condition:
+- type: dependency
+  job_id: "dep/job c"
+
+program:
+  type: no-op
+

--- a/vue/src/api.js
+++ b/vue/src/api.js
@@ -8,6 +8,10 @@ function getUrl(...path) {
   return url
 }
 
+export function getDependenciesUrl(run_id) {
+  return getUrl('runs', run_id, 'dependencies')
+}
+
 export function getMarkUrl(run_id, state) {
   return getUrl('runs', run_id, 'mark', state)
 }

--- a/vue/src/components/RunDependencies.vue
+++ b/vue/src/components/RunDependencies.vue
@@ -1,0 +1,154 @@
+<template lang="pug">
+div.dependencies
+  div
+  div.l Job
+  div.c Run
+  div.c State
+  div.r Schedule
+  div.r Start
+  div.r Elapsed
+  div.underline1(style="grid-column-end: span 7")
+
+  template(v-if="dependencies !== null")
+    div.colhead.v(:style="{ 'grid-row-end': 'span ' + dependencies.reduce((s, d) => s + Math.max(d.runs.length, 1), 1) }") Dependencies
+    template(v-for="dep, d of dependencies")
+      div.l.col-job(:style="{ 'grid-row-end': 'span ' + dep.runs.length }")
+        div.v: JobWithArgs(:job-id="dep.job_id" :args="dep.args")
+      template(v-for="r, i of dep.runs")
+        div.c.col-run: Run(:run-id="r.run_id")
+        div.c.col-state: State(:state="r.state")
+        div.r.col-schedule-time: Timestamp(:time="r.times.schedule")
+        div.r.col-start-time: Timestamp(v-if="r.times.running" :time="r.times.running")
+        div.r.col-elapsed: RunElapsed(:run="r")
+      div(v-if="dep.runs.length == 0")
+        div.c.col-run(style="grid-column-end: span 6") (no runs)
+        div
+        div
+        div
+        div
+      div(v-if="d < dependencies.length - 1" style="grid-column-end: span 6; border-bottom: 2px dotted #ccc;")
+    div(v-if="dependencies.length == 0" style="grid-column-end: span 6") (no dependencies)
+
+  div.underline1(style="grid-column-end: span 7")
+
+  div.colhead.v: span: b This run
+  div.l.col-job: JobWithArgs(:job-id="run.job_id" :args="run.args")
+  div.c.col-run: Run(:run-id="run.run_id")
+  div.c.col-state: State(:state="run.state")
+  div.r.col-schedule-time: Timestamp(:time="run.times.schedule")
+  div.r.col-start-time: Timestamp(v-if="run.times.running" :time="run.times.running")
+  div.r.col-elapsed: RunElapsed(:run="run")
+
+  div.underline1(style="grid-column-end: span 7")
+
+  template(v-if="dependents !== null")
+    div.colhead.v(:style="{ 'grid-row-end': 'span ' + dependents.reduce((s, d) => s + Math.max(d.runs.length, 1), 1) }") Dependents
+    template(v-for="dep, d of dependents")
+      div.l.col-job(:style="{ 'grid-row-end': 'span ' + dep.runs.length }")
+        div.v: JobWithArgs(:job-id="dep.job_id" :args="dep.args")
+      template(v-for="r, i of dep.runs")
+        div.c.col-run: Run(:run-id="r.run_id")
+        div.c.col-state: State(:state="r.state")
+        div.r.col-schedule-time: Timestamp(:time="r.times.schedule")
+        div.r.col-start-time: Timestamp(v-if="r.times.running" :time="r.times.running")
+        div.r.col-elapsed: RunElapsed(:run="r")
+      div(v-if="dep.runs.length == 0")
+        div.c.col-run(style="grid-column-end: span 6") (no runs)
+        div
+        div
+        div
+        div
+      div(v-if="d < dependents.length - 1" style="grid-column-end: span 6; border-bottom: 2px dotted #ccc;")
+    div(v-if="dependents.length == 0" style="grid-column-end: span 6") (no dependents)
+</template>
+
+<script>
+import JobWithArgs from '@/components/JobWithArgs'
+import Run from '@/components/Run'
+import { getDependencies, getDependents } from '@/runs'
+import RunElapsed from '@/components/RunElapsed'
+import State from '@/components/State'
+import store from '@/store'
+import Timestamp from '@/components/Timestamp'
+
+export default {
+  props: ['run'],
+  components: {
+    JobWithArgs,
+    Run,
+    RunElapsed,
+    State,
+    Timestamp,
+  },
+
+  data() {
+    return {
+    }
+  },
+
+  computed: {
+    dependencies() {
+      return this.run ? getDependencies(this.run, store) : null
+    },
+
+    dependents() {
+      return this.run ? getDependents(this.run, store) : null
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+@import '@/styles/index.scss';
+
+.dependencies {
+  display: grid;
+  grid-template-columns: repeat(7, max-content);
+  column-gap: 8px;
+  row-gap: 2px;
+  padding: 16px 0;
+
+  > div {
+    margin: 4px 4px;
+  }
+
+  > .l { text-align: left; }
+  > .c { text-align: center; }
+  > .r { justify-self: end; }
+
+  .v {
+    height: 100%;
+    display: flex;
+    align-items: center;
+  }
+
+  .colhead {
+    margin-top: 0;
+    margin-right: 0;
+    padding-right: 16px;
+    border-right: 2px dotted #ccc;
+  }
+
+  .underline1 {
+    border-bottom: 2px solid #ccc;
+  }
+
+  .col-job {
+  }
+
+  .col-run {
+  }
+
+  .col-state {
+  }
+
+  .col-schedule-time, .col-start-time {
+    font-size: 90%;
+    color: $global-light-color;
+  }
+
+  .col-elapsed {
+    white-space: nowrap;
+  }
+}
+</style>

--- a/vue/src/components/RunDependencies.vue
+++ b/vue/src/components/RunDependencies.vue
@@ -21,13 +21,13 @@ div.dependencies
         div.r.col-start-time: Timestamp(v-if="r.times.running" :time="r.times.running")
         div.r.col-elapsed: RunElapsed(:run="r")
       div(v-if="dep.runs.length == 0")
-        div.c.col-run(style="grid-column-end: span 6") (no runs)
+        div.c.col-run.colspan6 (no runs)
         div
         div
         div
         div
-      div(v-if="d < dependencies.length - 1" style="grid-column-end: span 6; border-bottom: 2px dotted #ccc;")
-    div(v-if="dependencies.length == 0" style="grid-column-end: span 6") (no dependencies)
+      div.colspan6(v-if="d < dependencies.length - 1" style="border-bottom: 2px dotted #ccc;")
+    div.colspan6(v-if="dependencies.length == 0") (no dependencies)
 
   div.underline1(style="grid-column-end: span 7")
 
@@ -53,13 +53,13 @@ div.dependencies
         div.r.col-start-time: Timestamp(v-if="r.times.running" :time="r.times.running")
         div.r.col-elapsed: RunElapsed(:run="r")
       div(v-if="dep.runs.length == 0")
-        div.c.col-run(style="grid-column-end: span 6") (no runs)
+        div.c.col-run.colspan6 (no runs)
         div
         div
         div
         div
-      div(v-if="d < dependents.length - 1" style="grid-column-end: span 6; border-bottom: 2px dotted #ccc;")
-    div(v-if="dependents.length == 0" style="grid-column-end: span 6") (no dependents)
+      div.colspan6(v-if="d < dependents.length - 1" style="border-bottom: 2px dotted #ccc;")
+    div.colspan6(v-if="dependents.length == 0") (no dependents)
 </template>
 
 <script>
@@ -110,6 +110,10 @@ export default {
 
   > div {
     margin: 4px 4px;
+  }
+
+  .colspan6 {
+    grid-column-end: span 6;
   }
 
   > .l { text-align: left; }

--- a/vue/src/components/RunDependencies.vue
+++ b/vue/src/components/RunDependencies.vue
@@ -12,11 +12,10 @@ div.dependencies
   template(v-if="dependencies !== null")
     div.colhead.v(:style="{ 'grid-row-end': 'span ' + dependencies.reduce((s, d) => s + (d.runs.length || 1), 1) }") Dependencies
     template(v-for="dep, d of dependencies")
-      div.l.col-job(:style="{ 'grid-row-end': 'span ' + dep.runs.length }")
-        div.v.stack
-          div: JobWithArgs(:job-id="dep.job_id" :args="dep.args")
-          div.omit(v-if="dep.runs.length > MAX_RUNS") last {{ MAX_RUNS }} of {{ dep.runs.length }}
-      template(v-for="r, i of dep.runs")
+      div.l.col-job.stack(:style="{ 'grid-row-end': 'span ' + dep.runs.length }")
+        div: JobWithArgs(:job-id="dep.job_id" :args="dep.args")
+        div.omit(v-if="dep.runs.length > MAX_RUNS") last {{ MAX_RUNS }} of {{ dep.runs.length }}
+      template(v-for="r, i of dep.runs.slice(-MAX_RUNS)")
         div.c.col-run: Run(:run-id="r.run_id")
         div.c.col-state: State(:state="r.state")
         div.r.col-schedule-time: Timestamp(:time="r.times.schedule")

--- a/vue/src/components/RunDependencies.vue
+++ b/vue/src/components/RunDependencies.vue
@@ -10,10 +10,12 @@ div.dependencies
   div.underline1(style="grid-column-end: span 7")
 
   template(v-if="dependencies !== null")
-    div.colhead.v(:style="{ 'grid-row-end': 'span ' + dependencies.reduce((s, d) => s + Math.max(d.runs.length, 1), 1) }") Dependencies
+    div.colhead.v(:style="{ 'grid-row-end': 'span ' + dependencies.reduce((s, d) => s + (d.runs.length || 1), 1) }") Dependencies
     template(v-for="dep, d of dependencies")
       div.l.col-job(:style="{ 'grid-row-end': 'span ' + dep.runs.length }")
-        div.v: JobWithArgs(:job-id="dep.job_id" :args="dep.args")
+        div.v.stack
+          div: JobWithArgs(:job-id="dep.job_id" :args="dep.args")
+          div.omit(v-if="dep.runs.length > MAX_RUNS") last {{ MAX_RUNS }} of {{ dep.runs.length }}
       template(v-for="r, i of dep.runs")
         div.c.col-run: Run(:run-id="r.run_id")
         div.c.col-state: State(:state="r.state")
@@ -83,6 +85,8 @@ export default {
 
   data() {
     return {
+      // Max number of runs matching job instance to show.
+      MAX_RUNS: 8,
     }
   },
 
@@ -105,7 +109,7 @@ export default {
   display: grid;
   grid-template-columns: repeat(7, max-content);
   column-gap: 8px;
-  row-gap: 2px;
+  row-gap: 1px;
   padding: 16px 0;
 
   > div {
@@ -124,6 +128,18 @@ export default {
     height: 100%;
     display: flex;
     align-items: center;
+  }
+
+  .stack {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    row-gap: 8px;
+  }
+
+  .omit {
+    font-size: 85%;
+    color: #aaa;
   }
 
   .colhead {

--- a/vue/src/runs.js
+++ b/vue/src/runs.js
@@ -199,3 +199,13 @@ export function includesAll(arr0, arr1) {
   return true
 }
 
+export function getDependencies(run, store) {
+  return run.conds
+    .filter(c => c.type === 'dependency')
+    .map(c => ({
+      job_id: c.job_id,
+      args: c.args,
+      states: c.states,
+      runs: store.getRunsForInstance(c.job_id, c.args),
+    }))
+}

--- a/vue/src/store.js
+++ b/vue/src/store.js
@@ -1,4 +1,4 @@
-import { filter, some } from 'lodash'
+import { filter, isEqual, some } from 'lodash'
 import { formatTime } from '@/time'
 
 class Errors {
@@ -62,6 +62,14 @@ class Store {
   setTimeZone(timeZone) {
     this.state.timeZone = timeZone
     this.state.timeStr = formatTime(this.state.time, this.state.timeZone)
+  }
+
+  getRunsForInstance(job_id, args) {
+    // FIXME: Optimize.
+    return Array.from(
+      this.state.runs.values()
+        .filter(r => r.job_id === job_id && isEqual(r.args, args))
+    )
   }
 
   _tick() {

--- a/vue/src/views/RunView.vue
+++ b/vue/src/views/RunView.vue
@@ -115,6 +115,25 @@ div
 
         div.underline1(style="grid-column-end: span 7")
 
+        template(v-if="dependents !== null")
+          div.colhead.v(:style="{ 'grid-row-end': 'span ' + dependents.reduce((s, d) => s + Math.max(d.runs.length, 1), 1) }") Dependents
+          template(v-for="dep, d of dependents")
+            div.l.col-job(:style="{ 'grid-row-end': 'span ' + dep.runs.length }")
+              div.v: JobWithArgs(:job-id="dep.job_id" :args="dep.args")
+            template(v-for="r, i of dep.runs")
+              div.c.col-run: Run(:run-id="r.run_id")
+              div.c.col-state: State(:state="r.state")
+              div.r.col-schedule-time: Timestamp(:time="r.times.schedule")
+              div.r.col-start-time: Timestamp(v-if="r.times.running" :time="r.times.running")
+              div.r.col-elapsed: RunElapsed(:run="r")
+            div(v-if="dep.runs.length == 0")
+              div.c.col-run(style="grid-column-end: span 6") (no runs)
+              div
+              div
+              div
+              div
+            div(v-if="d < dependents.length - 1" style="grid-column-end: span 6; border-bottom: 2px dotted #ccc;")
+          div(v-if="dependents.length == 0" style="grid-column-end: span 6") (no dependents)
 
     Frame(title="Metadata" closed)
       table.fields
@@ -164,7 +183,7 @@ import JobWithArgs from '@/components/JobWithArgs'
 import OperationButton from '@/components/OperationButton'
 import Program from '@/components/Program'
 import Run from '@/components/Run'
-import { getDependencies, isComplete, OPERATIONS } from '@/runs'
+import { getDependencies, getDependents, isComplete, OPERATIONS } from '@/runs'
 import RunArgs from '@/components/RunArgs'
 import RunElapsed from '@/components/RunElapsed'
 import RunsList from '@/components/RunsList'
@@ -234,6 +253,10 @@ export default {
 
     dependencies() {
       return this.run && this.run.conds ? getDependencies(this.run, this.store) : null
+    },
+
+    dependents() {
+      return this.run && this.run.conds ? getDependents(this.run, this.store) : null
     },
   },
 

--- a/vue/src/views/RunView.vue
+++ b/vue/src/views/RunView.vue
@@ -67,81 +67,7 @@ div
               td {{ rec.message }}
 
     Frame(title="Dependencies")
-      div.dependencies
-        div
-        div.l Job
-        div.c Run
-        div.c State
-        div.r Schedule
-        div.r Start
-        div.r Elapsed
-        div.underline1(style="grid-column-end: span 7")
-
-        template(v-if="dependencies !== null")
-          div.colhead.v(:style="{ 'grid-row-end': 'span ' + dependencies.reduce((s, d) => s + Math.max(d.runs.length, 1), 1) }") Dependencies
-          template(v-for="dep, d of dependencies")
-            div.l.col-job(:style="{ 'grid-row-end': 'span ' + dep.runs.length }")
-              div.v: JobWithArgs(:job-id="dep.job_id" :args="dep.args")
-            template(v-for="r, i of dep.runs")
-              div.c.col-run: Run(:run-id="r.run_id")
-              div.c.col-state: State(:state="r.state")
-              div.r.col-schedule-time: Timestamp(:time="r.times.schedule")
-              div.r.col-start-time: Timestamp(v-if="r.times.running" :time="r.times.running")
-              div.r.col-elapsed: RunElapsed(:run="r")
-            div(v-if="dep.runs.length == 0")
-              div.c.col-run(style="grid-column-end: span 6") (no runs)
-              div
-              div
-              div
-              div
-            div(v-if="d < dependencies.length - 1" style="grid-column-end: span 6; border-bottom: 2px dotted #ccc;")
-          div(v-if="dependencies.length == 0" style="grid-column-end: span 6") (no dependencies)
-
-        div.underline1(style="grid-column-end: span 7")
-
-        div.colhead.v: span: b This run
-        div.l.col-job: JobWithArgs(:job-id="run.job_id" :args="run.args")
-        div.c.col-run: Run(:run-id="run_id")
-        div.c.col-state: State(:state="run.state")
-        div.r.col-schedule-time: Timestamp(:time="run.times.schedule")
-        div.r.col-start-time: Timestamp(v-if="run.times.running" :time="run.times.running")
-        div.r.col-elapsed: RunElapsed(:run="run")
-
-        div.underline1(style="grid-column-end: span 7")
-
-        template(v-if="dependents !== null")
-          div.colhead.v(:style="{ 'grid-row-end': 'span ' + dependents.reduce((s, d) => s + Math.max(d.runs.length, 1), 1) }") Dependents
-          template(v-for="dep, d of dependents")
-            div.l.col-job(:style="{ 'grid-row-end': 'span ' + dep.runs.length }")
-              div.v: JobWithArgs(:job-id="dep.job_id" :args="dep.args")
-            template(v-for="r, i of dep.runs")
-              div.c.col-run: Run(:run-id="r.run_id")
-              div.c.col-state: State(:state="r.state")
-              div.r.col-schedule-time: Timestamp(:time="r.times.schedule")
-              div.r.col-start-time: Timestamp(v-if="r.times.running" :time="r.times.running")
-              div.r.col-elapsed: RunElapsed(:run="r")
-            div(v-if="dep.runs.length == 0")
-              div.c.col-run(style="grid-column-end: span 6") (no runs)
-              div
-              div
-              div
-              div
-            div(v-if="d < dependents.length - 1" style="grid-column-end: span 6; border-bottom: 2px dotted #ccc;")
-          div(v-if="dependents.length == 0" style="grid-column-end: span 6") (no dependents)
-
-    Frame(title="Metadata" closed)
-      table.fields
-        tbody
-          tr(v-for="(value, key) in meta && meta.program || {}" :key="key")
-            th {{ key }}
-            td
-              tt(v-if="typeof value === 'object'")
-                table.fields.subfields
-                  tbody
-                    tr(v-for="(sv, sk) in value" :key="sk")
-                      th {{ sk }}
-                      td {{ sv }}
-              tt(v-else) {{ value }}
+      RunDependencies(:run="run")
 
     Frame(title="Output" v-if="hasOutput")
       div.output(v-if="outputMetadata")
@@ -177,8 +103,9 @@ import JobWithArgs from '@/components/JobWithArgs'
 import OperationButton from '@/components/OperationButton'
 import Program from '@/components/Program'
 import Run from '@/components/Run'
-import { getDependencies, getDependents, isComplete, OPERATIONS } from '@/runs'
+import { isComplete, OPERATIONS } from '@/runs'
 import RunArgs from '@/components/RunArgs'
+import RunDependencies from '@/components/RunDependencies'
 import RunElapsed from '@/components/RunElapsed'
 import RunsList from '@/components/RunsList'
 import State from '@/components/State'
@@ -197,6 +124,7 @@ export default {
     Program,
     Run,
     RunArgs,
+    RunDependencies,
     RunElapsed,
     RunsList,
     State,
@@ -243,14 +171,6 @@ export default {
 
     metadata() {
       return this.metadata ? this.metadata.program || {} : {}
-    },
-
-    dependencies() {
-      return this.run ? getDependencies(this.run, this.store) : null
-    },
-
-    dependents() {
-      return this.run ? getDependents(this.run, this.store) : null
     },
   },
 
@@ -432,57 +352,6 @@ export default {
 
 .buttons {
   margin-bottom: 1.5rem;
-}
-
-.dependencies {
-  display: grid;
-  grid-template-columns: repeat(7, max-content);
-  column-gap: 8px;
-  row-gap: 2px;
-  padding: 16px 0;
-
-  > div {
-    margin: 4px 4px;
-  }
-
-  > .l { text-align: left; }
-  > .c { text-align: center; }
-  > .r { justify-self: end; }
-
-  .v {
-    height: 100%;
-    display: flex;
-    align-items: center;
-  }
-
-  .colhead {
-    margin-top: 0;
-    margin-right: 0;
-    padding-right: 16px;
-    border-right: 2px dotted #ccc;
-  }
-
-  .underline1 {
-    border-bottom: 2px solid #ccc;
-  }
-
-  .col-job {
-  }
-
-  .col-run {
-  }
-
-  .col-state {
-  }
-
-  .col-schedule-time, .col-start-time {
-    font-size: 90%;
-    color: $global-light-color;
-  }
-
-  .col-elapsed {
-    white-space: nowrap;
-  }
 }
 
 .output {

--- a/vue/src/views/RunView.vue
+++ b/vue/src/views/RunView.vue
@@ -99,7 +99,7 @@ div
 
         div.underline1(style="grid-column-end: span 7")
 
-        div.colhead.v: span This run
+        div.colhead.v: span: b This run
         div.l.col-job: JobWithArgs(:job-id="run.job_id" :args="run.args")
         div.c.col-run: Run(:run-id="run_id")
         div.c.col-state: State(:state="run.state")

--- a/vue/src/views/RunView.vue
+++ b/vue/src/views/RunView.vue
@@ -73,38 +73,47 @@ div
               td {{ rec.message }}
 
     Frame(title="Dependencies")
-      table.dependencies.widetable
-        thead: tr
-          td.no-underline
-          td.col-job Job
-          td.col-run Run
-          td.col-state State
-          td.col-schedule-time Schedule
-          td.col-start-time Start
-          td.col-elapsed Elapsed
-        tbody
-          template(v-if="dependencies" v-for="dep, j of dependencies")
-            tr(v-for="r, i of dep.runs")
-              td: span(v-if="i == 0 && j == 0") Dependencies
-              td.col-job(v-if="i == 0" :rowspan="dep.runs.length" style="display: flex, align-items: stretch"): div.right-bar: JobWithArgs(:job-id="dep.job_id" :args="dep.args")
-              td.col-run: Run(:run-id="r.run_id")
-              td.col-state: State(:state="r.state")
-              td.col-schedule-time: Timestamp(:time="r.times.schedule")
-              td.col-start-time: Timestamp(v-if="r.times.running" :time="r.times.running")
-              td.col-elapsed: RunElapsed(:run="r")
-            tr(v-if="dep.runs.length == 0")
-              td: span(v-if="j == 0") Dependencies
-              td.col-job: JobWithArgs(:job-id="dep.job_id" :args="dep.args")
-              td.col-run no runs
+      div.dependencies
+        div
+        div.l Job
+        div.c Run
+        div.c State
+        div.r Schedule
+        div.r Start
+        div.r Elapsed
+        div.underline1(style="grid-column-end: span 7")
 
-          tr
-            td: span This run
-            td.col-job: JobWithArgs(:job-id="run.job_id" :args="run.args")
-            td.col-run: Run(:run-id="run_id")
-            td.col-state: State(:state="run.state")
-            td.col-schedule-time: Timestamp(:time="run.times.schedule")
-            td.col-start-time: Timestamp(v-if="run.times.running" :time="run.times.running")
-            td.col-elapsed: RunElapsed(:run="run")
+        template(v-if="dependencies !== null")
+          div.colhead.v(:style="{ 'grid-row-end': 'span ' + dependencies.reduce((s, d) => s + Math.max(d.runs.length, 1), 1) }") Dependencies
+          template(v-for="dep, d of dependencies")
+            div.l.col-job(:style="{ 'grid-row-end': 'span ' + dep.runs.length }")
+              div.v: JobWithArgs(:job-id="dep.job_id" :args="dep.args")
+            template(v-for="r, i of dep.runs")
+              div.c.col-run: Run(:run-id="r.run_id")
+              div.c.col-state: State(:state="r.state")
+              div.r.col-schedule-time: Timestamp(:time="r.times.schedule")
+              div.r.col-start-time: Timestamp(v-if="r.times.running" :time="r.times.running")
+              div.r.col-elapsed: RunElapsed(:run="r")
+            div(v-if="dep.runs.length == 0")
+              div.c.col-run(style="grid-column-end: span 6") (no runs)
+              div
+              div
+              div
+              div
+            div(v-if="d < dependencies.length - 1" style="grid-column-end: span 6; border-bottom: 2px dotted #ccc;")
+          div(v-if="dependencies.length == 0" style="grid-column-end: span 6") (no dependencies)
+
+        div.underline1(style="grid-column-end: span 7")
+
+        div.colhead.v: span This run
+        div.l.col-job: JobWithArgs(:job-id="run.job_id" :args="run.args")
+        div.c.col-run: Run(:run-id="run_id")
+        div.c.col-state: State(:state="run.state")
+        div.r.col-schedule-time: Timestamp(:time="run.times.schedule")
+        div.r.col-start-time: Timestamp(v-if="run.times.running" :time="run.times.running")
+        div.r.col-elapsed: RunElapsed(:run="run")
+
+        div.underline1(style="grid-column-end: span 7")
 
 
     Frame(title="Metadata" closed)
@@ -410,40 +419,50 @@ export default {
 }
 
 .dependencies {
-  .no-underline {
-    border-bottom: 1px solid transparent;
+  display: grid;
+  grid-template-columns: repeat(7, max-content);
+  column-gap: 8px;
+
+  > div {
+    margin: 4px 4px;
   }
 
-  .right-bar {
+  > .l { text-align: left; }
+  > .c { text-align: center; }
+  > .r { justify-self: end; }
+
+  .v {
     height: 100%;
-    display: inline-block;
-    border-right: 1px solid #aaa;
+    display: flex;
+    align-items: center;
+  }
+
+  .colhead {
+    margin-top: 0;
+    margin-right: 0;
+    padding-right: 16px;
+    border-right: 2px dotted #ccc;
+  }
+
+  .underline1 {
+    border-bottom: 2px solid #ccc;
   }
 
   .col-job {
-    height: 100%;
-    text-align: left;
-    vertical-align: center;
   }
 
   .col-run {
-    text-align: center;
   }
 
   .col-state {
-    text-align: center;
-    vertical-align: bottom;
   }
 
   .col-schedule-time, .col-start-time {
     font-size: 90%;
     color: $global-light-color;
-    text-align: right;
   }
 
   .col-elapsed {
-    padding-right: 1em;
-    text-align: right;
     white-space: nowrap;
   }
 }

--- a/vue/src/views/RunView.vue
+++ b/vue/src/views/RunView.vue
@@ -47,17 +47,11 @@ div
               th program
               td.no-padding: Program(:program="run.program")
 
-            //- FIXME: Do better here.
             tr
               th conditions
               td.no-padding: table.fields: tbody
                 tr(v-for="cond in run.conds" :key="cond.str")
-                  td(style="padding-left: 0")
-                    span(v-if="cond.type === 'dependency'")
-                      span dependency:
-                      JobWithArgs(:job-id="cond.job_id" :args="cond.args")
-                      span  is {{ join(cond.states, '|') }}
-                    span(v-else) {{ cond.str }}
+                  td(style="padding-left: 0") {{ cond.str }}
 
             tr
               th elapsed
@@ -252,11 +246,11 @@ export default {
     },
 
     dependencies() {
-      return this.run && this.run.conds ? getDependencies(this.run, this.store) : null
+      return this.run ? getDependencies(this.run, this.store) : null
     },
 
     dependents() {
-      return this.run && this.run.conds ? getDependents(this.run, this.store) : null
+      return this.run ? getDependents(this.run, this.store) : null
     },
   },
 
@@ -270,7 +264,6 @@ export default {
           if (response.ok) {
             const run = (await response.json()).runs[this.run_id]
             this.run = Object.freeze(run)
-            console.log(this.run)
           }
           else if (response.status === 404)
             this.run = null
@@ -445,6 +438,8 @@ export default {
   display: grid;
   grid-template-columns: repeat(7, max-content);
   column-gap: 8px;
+  row-gap: 2px;
+  padding: 16px 0;
 
   > div {
     margin: 4px 4px;


### PR DESCRIPTION
Still to do:
- [x] limit number of runs that match a dependency /dependent job instance

This shows only directly dependencies and dependents.  Let's deploy this and see if there's still a strong need to show recursive dependencies directly.

Resolves #356 
