### PR TITLE
query runs columns explicitly

### DIFF
--- a/python/apsis/sqlite.py
+++ b/python/apsis/sqlite.py
@@ -258,6 +258,23 @@ TBL_RUNS = sa.Table(
     sa.Column("expected"    , sa.Boolean()      , nullable=True),
 )
 
+TBL_RUNS_SELECT = sa.select([
+    TBL_RUNS.columns[n]
+    for n in (
+        "rowid",
+        "run_id",
+        "timestamp",
+        "job_id",
+        "args",
+        "state",
+        "program",
+        "times",
+        "meta",
+        "message",
+        "run_state",
+    )
+])
+
 
 class RunDB:
 
@@ -272,11 +289,11 @@ class RunDB:
 
     @staticmethod
     def __query_runs(conn, expr):
-        query = sa.select([TBL_RUNS]).where(expr)
+        query = TBL_RUNS_SELECT.where(expr)
         cursor = conn.execute(query)
         for (
                 rowid, run_id, timestamp, job_id, args, state, program, times,
-                meta, message, run_state, _, _
+                meta, message, run_state,
         ) in cursor:
             if program is not None:
                 program     = Program.from_jso(ujson.loads(program))

--- a/python/apsis/sqlite.py
+++ b/python/apsis/sqlite.py
@@ -414,7 +414,6 @@ class RunDB:
         if min_timestamp is not None:
             where.append(TBL_RUNS.c.timestamp >= dump_time(min_timestamp))
 
-        # FIMXE: Return only the last record for each run_id?
         runs = list(self.__query_runs(self.__engine, sa.and_(*where)))
 
         log.debug(

--- a/python/apsis/sqlite.py
+++ b/python/apsis/sqlite.py
@@ -414,9 +414,8 @@ class RunDB:
         if min_timestamp is not None:
             where.append(TBL_RUNS.c.timestamp >= dump_time(min_timestamp))
 
-        with self.__engine.begin() as conn:
-            # FIMXE: Return only the last record for each run_id?
-            runs = list(self.__query_runs(conn, sa.and_(*where)))
+        # FIMXE: Return only the last record for each run_id?
+        runs = list(self.__query_runs(self.__engine, sa.and_(*where)))
 
         log.debug(
             f"query job_id={job_id} since={since} min_timestamp={min_timestamp}"

--- a/python/apsis/sqlite.py
+++ b/python/apsis/sqlite.py
@@ -364,10 +364,9 @@ class RunDB:
                     meta,
                     message,
                     run_state,
-                    rowid,
-                    expected
+                    rowid
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """, values)
             con.commit()
             run._rowid = values[-1]


### PR DESCRIPTION
This sets up for better backward compatibility of schema changes.
