### PR TITLE
improve conds/actions check

### DIFF
--- a/python/apsis/jobs.py
+++ b/python/apsis/jobs.py
@@ -338,9 +338,13 @@ class Jobs:
 
 
     def get_job(self, job_id) -> Job:
-        with suppress(LookupError):
+        try:
             return self.__jobs_dir.get_job(job_id)
-        return self.__job_db.get(job_id)
+        except LookupError:
+            try:
+                return self.__job_db.get(job_id)
+            except LookupError:
+                raise LookupError(f"unknown job ID: {job_id}") from None
 
 
     __getitem__ = get_job

--- a/python/apsis/lib/calendar.py
+++ b/python/apsis/lib/calendar.py
@@ -5,6 +5,11 @@ import ora.calendar
 
 # Cache calendars.  We assume on-disk calendars don't change during the
 # scheduler's lifetime.
-get_calendar = functools.cache(ora.calendar.get_calendar)
+@functools.cache
+def get_calendar(name):
+    try:
+        return ora.calendar.get_calendar(name)
+    except LookupError:
+        raise LookupError(f"no such calendar: {name}") from None
 
 


### PR DESCRIPTION
If we instantiated a run, don't check cond/action job references explicitly, to avoid duplicate messages.

Resolves #401 