### PR TITLE
Fix `load_jobs_dir`: raise `NotADirectoryError` when path is not a dir

### DIFF
--- a/python/apsis/jobs.py
+++ b/python/apsis/jobs.py
@@ -295,13 +295,15 @@ def load_jobs_dir(path):
 
     :return:
       The successfully loaded `JobsDir`.
+    :raise NotADirectoryError:
+      The provided path is not a directory.
     :raise JobsDirErrors:
       One or more errors while loading jobs.  The exception's `errors` attribute
       contains the errors; each has a `job_id` attribute.
     """
     jobs_path = Path(path)
     if not jobs_path.is_dir():
-        raise JobsDirErrors(f"not a directory: {jobs_path}", [])
+        raise NotADirectoryError(f"not a directory: {jobs_path}")
 
     jobs = {}
     errors = []

--- a/python/apsis/jobs.py
+++ b/python/apsis/jobs.py
@@ -296,7 +296,7 @@ def load_jobs_dir(path):
     :return:
       The successfully loaded `JobsDir`.
     :raise NotADirectoryError:
-      The `path` is not a directory.
+      `path` is not a directory.
     :raise JobsDirErrors:
       One or more errors while loading jobs.  The exception's `errors` attribute
       contains the errors; each has a `job_id` attribute.

--- a/python/apsis/jobs.py
+++ b/python/apsis/jobs.py
@@ -296,7 +296,7 @@ def load_jobs_dir(path):
     :return:
       The successfully loaded `JobsDir`.
     :raise NotADirectoryError:
-      The provided path is not a directory.
+      The `path` is not a directory.
     :raise JobsDirErrors:
       One or more errors while loading jobs.  The exception's `errors` attribute
       contains the errors; each has a `job_id` attribute.


### PR DESCRIPTION
## Before
```
[lrighi]🌐 appl112-ny2 in apsis [ master][?][📦 v0.28.3][🐍 v3.10.12][🅒 prod7]
> apsisctl check-jobs this/does/not/exist

```

## After
```
[lrighi]🌐 appl112-ny2 in apsis [ fix-load-jobs-dir][📦 v0.28.3][🐍 v3.10.12][🅒 prod7][⏱ 12s]
> apsisctl check-jobs this/does/not/exist

Usage:
  apsisctl [ OPTIONS ] COMMAND ...

apsisctl: error: not a directory: this/does/not/exist
```

cc @alexhsamuel 