### PR TITLE
check that deps are scheduled

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,9 @@
+# v0.29
+
+- `apsisctl check-jobs --check-dependencies-scheduled` attempts to check that
+  dependencies of scheduled runs are themselves scheduled.
+
+
 # v0.28
 
 - Apsis checks at startup that the job dir exists and all YAML files within it

--- a/docs/jobs.rst
+++ b/docs/jobs.rst
@@ -203,6 +203,19 @@ Keep in mind that Apsis run arguments are always strings, so Apsis converts the
 result using `str`.
 
 
+Checking jobs
+=============
+
+Invoke `apsisctl check-jobs JOBDIR` to load and check the jobs in a job
+directory.  This runs the same checks that Apsis uses when starting.
+
+With `--check-dependencies-scheduled`, this also attemps to check that the
+dependencies of each scheduled job are also scheduled.  This check is heuristic,
+as it checks dependencies only of runs scheduled in the next 24 hours, and
+considers only dependency runs scheduled in the last 24 hours and the next 24
+hours.
+
+
 Changes to jobs
 ===============
 

--- a/python/apsis/check.py
+++ b/python/apsis/check.py
@@ -1,0 +1,146 @@
+import ora
+
+from   apsis.cond.dependency import Dependency
+from   apsis.jobs import Jobs
+from   apsis.runs import Instance, Run, validate_args, bind
+from   apsis.scheduler import get_insts_to_schedule
+
+#-------------------------------------------------------------------------------
+
+# FIXME: Use normal protocols for this, not random APIs that need mocks.
+class MockJobDb:
+
+    def get(self, job_id):
+        raise LookupError(job_id)
+
+
+
+def check_job(jobs_dir, job):
+    """
+    Performs consistency checks on `job` in `jobs_dir`.
+
+    :return:
+      Generator of errors.
+    """
+    # Try scheduling a run for each schedule of each job.  This tests that
+    # template expansions work, that all names and params are bound, and that
+    # actions and conditions refer to valid jobs with correct args.
+    now = ora.now()
+    jobs = Jobs(jobs_dir, MockJobDb())
+    checked_run = False
+    for schedule in job.schedules:
+        try:
+            _, args = next(schedule(now))
+        except StopIteration:
+            continue
+        args = { a: str(v) for a, v in args.items() if a in job.params }
+        run = Run(Instance(job.job_id, args))
+        checked_run = True
+        try:
+            validate_args(run, job.params)
+            bind(run, job, jobs)
+        except Exception as exc:
+            yield str(exc)
+            continue
+
+    if not checked_run:
+        def check_associated_run(obj, context):
+            try:
+                associated_job_id = obj.job_id
+            except AttributeError:
+                # No associated job; that's OK.
+                return
+
+            # Find the associated job.
+            try:
+                associated_job = jobs_dir.get_job(associated_job_id)
+            except LookupError:
+                yield f"unknown job ID in {context}: {associated_job_id}"
+                return
+
+            # Look up additional args, if any.
+            try:
+                args = set(obj.args)
+            except AttributeError:
+                args = set()
+
+            params = set(associated_job.params)
+            # Check for missing args.  The params of the associated job can be bound
+            # either to the args of this job or to explicit args.
+            for missing in params - set(job.params) - args:
+                yield f"missing arg in {context}: param {missing} of job {associated_job_id}"
+            # Check for extraneous explicit args.
+            for extra in args - params:
+                yield f"extraneous arg in {context}: param {extra} of job {associated_job_id}"
+
+        # We couldn't construct a run to check.  At least confirm that any
+        # action or condition that refers to another job is valid.
+        for action in job.actions:
+            yield from check_associated_run(action, "action")
+        for cond in job.conds:
+            yield from check_associated_run(cond, "condition")
+
+
+def check_job_dependencies_scheduled(
+        jobs_dir,
+        job,
+        *,
+        sched_times=None,
+        dep_times=None,
+):
+    """
+    Attempts to check that dependencies are scheduled.
+
+    For each run of `job` scheduled within `sched_times`, looks for
+    dependencies.  For each dependency, checks that there is a matching run of
+    that job scheduled in `dep_times`.
+
+    :param sched_times:
+      (start, stop) time interval for scheduled runs of `job` to consider.  If
+      none, uses (now, now + 1 day).
+    :param dep_times:
+      (start, stop) time interval in which to look for scheduled runs of
+      dependencies.  If none, uses (now - 1 day, now + 1 day).
+    :return:
+      Generator of errors indicating apparently unscheduled dependencies.
+    """
+    deps = [ c for c in job.conds if isinstance(c, Dependency) ]
+    if len(deps) == 0:
+        return
+
+    jobs = Jobs(jobs_dir, MockJobDb())
+    time = ora.now()
+
+    sched_start, sched_stop = time, time + 86400
+    dep_start, dep_stop = time - 86400, time + 86400
+    dep_ivl = f"[{dep_start}, {dep_stop})"
+
+    for schedule in job.schedules:
+        # Construct all instances that will be scheduled soon.
+        insts = get_insts_to_schedule(job, sched_start, sched_stop)
+        # Check each of scheduled instance.
+        for _, inst in insts:
+            run = Run(inst)
+            # Check each dependency.
+            for dep in deps:
+                # Bind the dependency to get the precise args that match.
+                dep = dep.bind(run, jobs)
+
+                # Look at cheduled runs of the dependency job in `dep_times.
+                # Check if any matches the dependency args.
+                dep_job = jobs_dir.get_job(dep.job_id)
+                if not any(
+                        i.args == dep.args
+                        for _, i in get_insts_to_schedule(
+                                dep_job,
+                                dep_start, dep_stop
+                        )
+                ):
+                    # No matches.
+                    dep_inst = Instance(dep.job_id, dep.args)
+                    yield (
+                        f"scheduled run {inst}: "
+                        f"dependency {dep_inst} not scheduled in {dep_ivl}"
+                    )
+
+

--- a/python/apsis/ctl.py
+++ b/python/apsis/ctl.py
@@ -2,6 +2,7 @@
 Control CLI, for maintenance and running the service.
 """
 
+# Configure GC as early as possible.
 import gc
 gc.set_threshold(100_000, 100, 10)
 import apsis.lib.py
@@ -10,8 +11,10 @@ apsis.lib.py.track_gc_stats(warn_time=0.5)
 import logging
 import os
 from   pathlib import Path
+import sanic  # must be imported before apsis.lib.asyn
 import sys
 
+import apsis.check
 import apsis.cmdline
 import apsis.config
 from   apsis.exc import JobsDirErrors
@@ -78,7 +81,7 @@ def main():
 
         if jobs_dir is not None and args.check_dependencies_scheduled:
             for job in jobs_dir.get_jobs():
-                for err in apsis.jobs.check_job_dependencies_scheduled(jobs_dir, job):
+                for err in apsis.check.check_job_dependencies_scheduled(jobs_dir, job):
                     con.print(f"{job.job_id}: {err}", style="error")
                     status = 1
 

--- a/python/apsis/jobs.py
+++ b/python/apsis/jobs.py
@@ -1,6 +1,4 @@
-from   contextlib import suppress
 import logging
-import ora
 import os
 from   pathlib import Path
 import random
@@ -11,7 +9,6 @@ from   .actions import Action
 from   .actions.schedule import successor_from_jso
 from   .cond import Condition
 from   .exc import JobError, JobsDirErrors, SchemaError
-from   .lib import itr
 from   .lib.json import to_array, check_schema
 from   .lib.py import tupleize, format_ctor
 from   .program import Program, NoOpProgram
@@ -217,149 +214,6 @@ class JobsDir:
 
 
 
-# FIXME: Use normal protocols for this, not random APIs that need mocks.
-class MockJobDb:
-
-    def get(self, job_id):
-        raise LookupError(job_id)
-
-
-
-def check_job(jobs_dir, job):
-    """
-    Performs consistency checks on `job` in `jobs_dir`.
-
-    :return:
-      Generator of errors.
-    """
-    from apsis.runs import Instance, Run, validate_args, bind
-
-    # Try scheduling a run for each schedule of each job.  This tests that
-    # template expansions work, that all names and params are bound, and that
-    # actions and conditions refer to valid jobs with correct args.
-    now = ora.now()
-    jobs = Jobs(jobs_dir, MockJobDb())
-    checked_run = False
-    for schedule in job.schedules:
-        try:
-            _, args = next(schedule(now))
-        except StopIteration:
-            continue
-        args = { a: str(v) for a, v in args.items() if a in job.params }
-        run = Run(Instance(job.job_id, args))
-        checked_run = True
-        try:
-            validate_args(run, job.params)
-            bind(run, job, jobs)
-        except Exception as exc:
-            yield str(exc)
-            continue
-
-    if not checked_run:
-        def check_associated_run(obj, context):
-            try:
-                associated_job_id = obj.job_id
-            except AttributeError:
-                # No associated job; that's OK.
-                return
-
-            # Find the associated job.
-            try:
-                associated_job = jobs_dir.get_job(associated_job_id)
-            except LookupError:
-                yield f"unknown job ID in {context}: {associated_job_id}"
-                return
-
-            # Look up additional args, if any.
-            try:
-                args = set(obj.args)
-            except AttributeError:
-                args = set()
-
-            params = set(associated_job.params)
-            # Check for missing args.  The params of the associated job can be bound
-            # either to the args of this job or to explicit args.
-            for missing in params - set(job.params) - args:
-                yield f"missing arg in {context}: param {missing} of job {associated_job_id}"
-            # Check for extraneous explicit args.
-            for extra in args - params:
-                yield f"extraneous arg in {context}: param {extra} of job {associated_job_id}"
-
-        # We couldn't construct a run to check.  At least confirm that any
-        # action or condition that refers to another job is valid.
-        for action in job.actions:
-            yield from check_associated_run(action, "action")
-        for cond in job.conds:
-            yield from check_associated_run(cond, "condition")
-
-
-def check_job_dependencies_scheduled(
-        jobs_dir,
-        job,
-        *,
-        sched_times=None,
-        dep_times=None,
-):
-    """
-    Attempts to check that dependencies are scheduled.
-
-    For each run of `job` scheduled within `sched_times`, looks for
-    dependencies.  For each dependency, checks that there is a matching run of
-    that job scheduled in `dep_times`.
-
-    :param sched_times:
-      (start, stop) time interval for scheduled runs of `job` to consider.  If
-      none, uses (now, now + 1 day).
-    :param dep_times:
-      (start, stop) time interval in which to look for scheduled runs of
-      dependencies.  If none, uses (now - 1 day, now + 1 day).
-    :return:
-      Generator of errors indicating apparently unscheduled dependencies.
-    """
-    from apsis.cond.dependency import Dependency
-    from apsis.runs import Instance, Run
-    from apsis.scheduler import get_insts_to_schedule
-
-    deps = [ c for c in job.conds if isinstance(c, Dependency) ]
-    if len(deps) == 0:
-        return
-
-    jobs = Jobs(jobs_dir, MockJobDb())
-    time = ora.now()
-
-    sched_start, sched_stop = time, time + 86400
-    dep_start, dep_stop = time - 86400, time + 86400
-    dep_ivl = f"[{dep_start}, {dep_stop})"
-
-    for schedule in job.schedules:
-        # Construct all instances that will be scheduled soon.
-        insts = get_insts_to_schedule(job, sched_start, sched_stop)
-        # Check each of scheduled instance.
-        for _, inst in insts:
-            run = Run(inst)
-            # Check each dependency.
-            for dep in deps:
-                # Bind the dependency to get the precise args that match.
-                dep = dep.bind(run, jobs)
-
-                # Look at cheduled runs of the dependency job in `dep_times.
-                # Check if any matches the dependency args.
-                dep_job = jobs_dir.get_job(dep.job_id)
-                if not any(
-                        i.args == dep.args
-                        for _, i in get_insts_to_schedule(
-                                dep_job,
-                                dep_start, dep_stop
-                        )
-                ):
-                    # No matches.
-                    dep_inst = Instance(dep.job_id, dep.args)
-                    yield (
-                        f"scheduled run {inst}: "
-                        f"dependency {dep_inst} not scheduled in {dep_ivl}"
-                    )
-
-
 def load_jobs_dir(path):
     """
     Attempts to loads jobs from a jobs dir.
@@ -372,6 +226,8 @@ def load_jobs_dir(path):
       One or more errors while loading jobs.  The exception's `errors` attribute
       contains the errors; each has a `job_id` attribute.
     """
+    from .check import check_job
+
     jobs_path = Path(path)
     if not jobs_path.is_dir():
         raise NotADirectoryError(f"not a directory: {jobs_path}")

--- a/python/apsis/lib/asyn.py
+++ b/python/apsis/lib/asyn.py
@@ -13,6 +13,13 @@ def _install():
     Monkeypatches the event loop policy to augment new event loops with
     `on_close` behavior.
     """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        pass
+    else:
+        assert False, "event loop already running"
+
     policy = asyncio.get_event_loop_policy()
     old_new_event_loop = policy.new_event_loop
 

--- a/test/unit/test_check.py
+++ b/test/unit/test_check.py
@@ -1,7 +1,6 @@
-from   pathlib import Path
-import pytest
 from   typing import List
 
+import apsis.check
 from   apsis.cond.dependency import Dependency
 import apsis.jobs
 from   apsis.jobs import InMemoryJobs, Job
@@ -10,7 +9,7 @@ from   apsis.jobs import InMemoryJobs, Job
 
 def check_job(jobs, job_id) -> List[str]:
     job = jobs.get_job(job_id)
-    return list(apsis.jobs.check_job(jobs, job))
+    return list(apsis.check.check_job(jobs, job))
 
 
 def test_dependency_no_job():


### PR DESCRIPTION
Resolves #403

Because Apsis allows expressions in job schedules, it is not possible statically to determine whether dependencies will be scheduled.  Instead, this PR adds a check as follows.  For each job with at least one dependency:
- Determine all runs scheduled in the next 24 hours.  For each,
  - Consider its dependencies.  For each,
    - Determine all runs of the corresponding job that are scheduled in the last 24 hours and next 24 hours.
    - See if any of them match the dependency args.

Since this is heuristic, I'm not enabling it by default, either for Apsis's loading of jobs at startup, or for 'check-jobs'; it's an option for the latter.
