### PR TITLE
set sqlite timeout

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,8 @@
+# v0.30
+
+- Config `database.timeout` sets the sqlite lock timeout.
+
+
 # v0.29
 
 - `apsisctl check-jobs --check-dependencies-scheduled` attempts to check that

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -15,7 +15,9 @@ config file.
 .. code:: yaml
 
     jobs: ./jobs                # path
-    database: ./apsis.db        # path
+    database:
+      path: ./apsis.db          # path
+      timeout: 10s              # duration
 
     runs:
       lookback: null            # seconds
@@ -26,7 +28,7 @@ config file.
       horizon: 86400            # seconds
 
     waiting:
-      max_time: null            # seconds
+      max_time: null            # duration
 
     program_types:
       # ...
@@ -41,8 +43,8 @@ config file.
       # ...
 
 
-For durations in seconds, you may also use durations like `30s`, `10 min` (600
-seconds), `1.5h` (5400 seconds), and `1 day` (86400 seconds).
+A duration is in in seconds, or you may give durations like `30s`, `10 min`
+(600 seconds), `1.5h` (5400 seconds), and `1 day` (86400 seconds).
 
 
 Files
@@ -50,7 +52,9 @@ Files
 
 `jobdir` specifies the path to the directory containing job files.
 
-`database` specifies the path to the database file containing run state.
+`database.path` specifies the path to the database file containing run state.
+
+`database.timeout` specifies the lock timeout when accessing the database.
 
 
 Runs

--- a/python/apsis/lib/py.py
+++ b/python/apsis/lib/py.py
@@ -228,7 +228,7 @@ def format_repr(obj):
 
 def get_cfg(cfg, path, default):
     """
-    Retrieves a config by `path` from nested dict `cfg`.
+    Gets a config at `path` in nested dict `cfg`.
 
     :param path:
       A dotted path.
@@ -237,6 +237,24 @@ def get_cfg(cfg, path, default):
     for sub in subs:
         cfg = cfg.get(sub, {})
     return cfg.get(last, default)
+
+
+def set_cfg(cfg, path, value):
+    """
+    Sets a config at `path` in nested dict `cfg`.
+
+      >>> cfg = {}
+      >>> set_cfg(cfg, "foo.bar.baz", 10)
+      >>> cfg
+      {'foo': {'bar': {'baz': 10}}}
+
+    :param path:
+      A dotted path.
+    """
+    *subs, last = path.split(".")
+    for sub in subs:
+        cfg = cfg.setdefault(sub, {})
+    cfg[last] = value
 
 
 def look_up(name, obj):

--- a/python/apsis/service/main.py
+++ b/python/apsis/service/main.py
@@ -65,10 +65,11 @@ app.static("/static", str(vue_dir / "static"))
 #-------------------------------------------------------------------------------
 
 def build_apsis(cfg):
-    db_path = cfg["database"]
+    db_cfg = cfg["database"]
+    db_path = db_cfg["path"]
 
     log.info(f"opening state file {db_path}")
-    db = SqliteDB.open(db_path)
+    db = SqliteDB.open(db_path, timeout=db_cfg.get("timeout"))
 
     job_dir = cfg["job_dir"]
     log.info(f"opening jobs dir {job_dir}")

--- a/python/apsis/sqlite.py
+++ b/python/apsis/sqlite.py
@@ -665,8 +665,6 @@ class SqliteDB:
             poolclass=sa.pool.StaticPool,
             connect_args=connect_args,
         )
-        (busy_timeout, ), = engine.execute("PRAGMA busy_timeout")
-        log.info(f"busy_timeout = {busy_timeout}")
         return engine
 
 

--- a/python/apsis/sqlite.py
+++ b/python/apsis/sqlite.py
@@ -651,12 +651,23 @@ class SqliteDB:
 
 
     @classmethod
-    def __get_engine(cls, path):
+    def __get_engine(cls, path, *, timeout=None):
         url = "sqlite://" if path is None else f"sqlite:///{path}"
+        connect_args = {}
+        if timeout is not None:
+            connect_args["timeout"] = timeout
+
         # Use a static pool-- exactly one persistent connection-- since we are a
         # single-threaded async application, and sqlite doesn't support
         # concurrent access.
-        return sa.create_engine(url, poolclass=sa.pool.StaticPool)
+        engine = sa.create_engine(
+            url,
+            poolclass=sa.pool.StaticPool,
+            connect_args=connect_args,
+        )
+        (busy_timeout, ), = engine.execute("PRAGMA busy_timeout")
+        log.info(f"busy_timeout = {busy_timeout}")
+        return engine
 
 
     def close(self):
@@ -688,13 +699,13 @@ class SqliteDB:
 
 
     @classmethod
-    def open(cls, path):
+    def open(cls, path, *, timeout=None):
         if path is not None:
             path = Path(path).absolute()
             if not path.exists():
                 raise FileNotFoundError(path)
 
-        engine  = cls.__get_engine(path)
+        engine  = cls.__get_engine(path, timeout=timeout)
         # FIXME: Check that tables exist.
         return cls(engine)
 

--- a/test/int/instance.py
+++ b/test/int/instance.py
@@ -54,7 +54,9 @@ class ApsisService:
 
     def write_cfg(self):
         cfg = self.cfg | {
-            "database": str(self.db_path),
+            "database": {
+                "path": str(self.db_path),
+            },
             "job_dir": str(self.jobs_dir),
         }
         with open(self.cfg_path, "w") as file:

--- a/test/manual/procstar/config.yaml
+++ b/test/manual/procstar/config.yaml
@@ -1,4 +1,6 @@
-database: apsis.db
+database:
+  path: apsis.db
+  timeout: 0.1m
 jobs: jobs
 
 procstar:


### PR DESCRIPTION
The database config now looks like:
```yaml
database:
  path: path/to/my/apsis.db
  timeout: 10s
```

Still accepts the old `database: path` config for backward compatibility.

Resolves #413 
