### PR TITLE
Improve `check_job_dependencies_scheduled`

### DIFF
--- a/python/apsis/check.py
+++ b/python/apsis/check.py
@@ -100,7 +100,7 @@ def check_job_dependencies_scheduled(
       none, uses (now, now + 1 day).
     :param dep_times:
       (start, stop) time interval in which to look for scheduled runs of
-      dependencies.  If none, uses (now - 1 day, now + 1 day).
+      dependencies.  If none, uses (now - 2 days, now + 2 days).
     :return:
       Generator of errors indicating apparently unscheduled dependencies.
     """
@@ -115,7 +115,7 @@ def check_job_dependencies_scheduled(
         sched_times if sched_times is not None else (time, time + 86400)
     )
     dep_start, dep_stop = (
-        dep_times if dep_times is not None else (time - 86400, time + 86400)
+        dep_times if dep_times is not None else (time - 86400*2, time + 86400*2)
     )
     dep_ivl = f"[{dep_start}, {dep_stop})"
 

--- a/python/apsis/check.py
+++ b/python/apsis/check.py
@@ -126,7 +126,7 @@ def check_job_dependencies_scheduled(
                 # Bind the dependency to get the precise args that match.
                 dep = dep.bind(run, jobs)
 
-                # Look at cheduled runs of the dependency job in `dep_times.
+                # Look at scheduled runs of the dependency job in `dep_times`.
                 # Check if any matches the dependency args.
                 dep_job = jobs_dir.get_job(dep.job_id)
                 if not any(

--- a/python/apsis/check.py
+++ b/python/apsis/check.py
@@ -111,8 +111,12 @@ def check_job_dependencies_scheduled(
     jobs = Jobs(jobs_dir, MockJobDb())
     time = ora.now()
 
-    sched_start, sched_stop = time, time + 86400
-    dep_start, dep_stop = time - 86400, time + 86400
+    sched_start, sched_stop = (
+        sched_times if sched_times is not None else (time, time + 86400)
+    )
+    dep_start, dep_stop = (
+        dep_times if dep_times is not None else (time - 86400, time + 86400)
+    )
     dep_ivl = f"[{dep_start}, {dep_stop})"
 
     for schedule in job.schedules:


### PR DESCRIPTION
Hi Alex, I believe this check is a bit too strict as the time window in which to look for dependency runs is very tight.

You are basically assuming that if `job_A` depends on `job_B` the time at which `job_B` is scheduled is earlier (or same) than the time at which `job_A` is scheduled. I believe this assumption is a bit too strong (surely it is for us), also because the difference in times among time zones is not constant during the whole year.

####  `A.yaml` def:
```
schedule:
  type: daily
  tz: Europe/London
  calendar: all
  daytime: '17:00:00'
  
condition:
  - type: dependency
    job_id: B
```

####  `B.yaml` def:
```
schedule:
  type: daily
  tz: Europe/London
  calendar: all
  daytime: '18:00:00'
```
(at any time between 17:00 and 18:00):
```
A: scheduled run A(date=2024-12-12): dependency B(date=2024-12-12) not scheduled in [2024-12-10T17:32:55+00:00, 2024-12-12T17:32:55+00:00)
```



Moreover this also breaks in cases like the following, where the dependency is even scheduled earlier than the dependent.
####  `A.yaml` def:
```
schedule:
  type: daily
  tz: Europe/London
  calendar: all
  daytime: '18:00:00'
  
condition:
  - type: dependency
    job_id: B
    args:
      date: '{{Date(date) - 1}}'
```

####  `B.yaml` def:
```
schedule:
  type: daily
  tz: Europe/London
  calendar: all
  daytime: '17:00:00'
```
```
A: scheduled run A(date=2024-12-11): dependency B(date=2024-12-10) not scheduled in [2024-12-10T17:36:54+00:00, 2024-12-12T17:36:54+00:00)

```
----------------------------------------

Anyways, up to you whether to make the dependency window wider here (i.e., apply this commit https://github.com/alexhsamuel/apsis/commit/cad445621349b2dbcfb0d6ebfc64e0aeea3329bc); as long as we can pass `dep_times` to `check_job_dependencies_scheduled` from our side.
(Note: we have reimplemented `apsisctl check-jobs` to also add some extra checks that are ASD specific, so we directly invoke `check_job_dependencies_scheduled`).