### PR TITLE
Add `stop_time` column in `migrate_db.py` script

### DIFF
--- a/scripts/migrate-db.py
+++ b/scripts/migrate-db.py
@@ -46,6 +46,7 @@ with closing(sqlite3.connect(args.path)) as conn:
     for table_name, col_name, col_def in (
             ("runs", "conds", "VARCHAR NULL"),
             ("runs", "actions", "VARCHAR NULL"),
+            ("runs", "stop_time", "FLOAT NULL"),
     ):
         if not has_column(table_name, col_name):
             log.info(f"creating column: {table_name}.{col_name}")


### PR DESCRIPTION
Rerunning runs that were create with Apsis version `0.32.0.` currently triggers the following:

```
2025-01-17T12:18:33.302 sanic.error              E Exception occurred while handling uri: 'http://rd10.asd:5000/api/v1/runs/r7006314/rerun'
Traceback (most recent call last):
  File "/space/lrighi/apsis_tests/env/lib/python3.10/site-packages/sanic/app.py", line 770, in handle_request
    response = await response
  File "/home/lrighi/apsis/python/apsis/service/api.py", line 364, in run_rerun
    new_run = await state.rerun(run)
  File "/home/lrighi/apsis/python/apsis/apsis.py", line 594, in rerun
    new_run = await self.schedule(time, run.inst, stop_time=run.stop_time)
AttributeError: 'Run' object has no attribute 'stop_time'
2025-01-17T12:18:33.302 sanic.error              E Exception occurred while handling uri: 'http://rd10.asd:5000/api/v1/runs/r7006314/rerun'
Traceback (most recent call last):
  File "/space/lrighi/apsis_tests/env/lib/python3.10/site-packages/sanic/app.py", line 770, in handle_request
    response = await response
  File "/home/lrighi/apsis/python/apsis/service/api.py", line 364, in run_rerun
    new_run = await state.rerun(run)
  File "/home/lrighi/apsis/python/apsis/apsis.py", line 594, in rerun
    new_run = await self.schedule(time, run.inst, stop_time=run.stop_time)
AttributeError: 'Run' object has no attribute 'stop_time'

```