### PR TITLE
Prevent Apsis to freeze when jobs are loading

### DIFF
--- a/python/apsis/apsis.py
+++ b/python/apsis/apsis.py
@@ -872,7 +872,7 @@ async def reload_jobs(apsis, *, dry_run=False):
 
     # Reload the contents of the jobs dir.
     log.info(f"reloading jobs from {jobs0.path}")
-    jobs1 = load_jobs_dir(jobs0.path)
+    jobs1 = await load_jobs_dir(jobs0.path)
 
     # Diff them.
     rem_ids, add_ids, chg_ids = diff_jobs_dirs(jobs0, jobs1)

--- a/python/apsis/jobs.py
+++ b/python/apsis/jobs.py
@@ -249,7 +249,7 @@ async def load_jobs_dir(path):
             try:
                 async with aiofiles.open(path, mode='r') as file:
                     content = await file.read()
-                job_jso = await asyncio.to_thread(yaml.safe_load, content)
+                job_jso = yaml.safe_load(content)
                 job = Job.from_jso(job_jso, job_id)
                 return job_id, job, None
             except SchemaError as exc:

--- a/python/apsis/jobs.py
+++ b/python/apsis/jobs.py
@@ -241,21 +241,19 @@ async def load_jobs_dir(path):
 
     jobs = {}
     errors = []
-    semaphore = asyncio.Semaphore(10)
 
     async def load_job(path, job_id):
-        async with semaphore:
-            log.debug(f"loading: {path}")
-            try:
-                async with aiofiles.open(path, mode='r') as file:
-                    content = await file.read()
-                job_jso = yaml.safe_load(content)
-                job = Job.from_jso(job_jso, job_id)
-                return job_id, job, None
-            except SchemaError as exc:
-                log.debug(f"error: {path}: {exc}", exc_info=True)
-                exc.job_id = job_id
-                return job_id, None, exc
+        log.debug(f"loading: {path}")
+        try:
+            async with aiofiles.open(path, mode='r') as file:
+                content = await file.read()
+            job_jso = yaml.safe_load(content)
+            job = Job.from_jso(job_jso, job_id)
+            return job_id, job, None
+        except SchemaError as exc:
+            log.debug(f"error: {path}: {exc}", exc_info=True)
+            exc.job_id = job_id
+            return job_id, None, exc
 
     load_coros = [
         load_job(path, job_id)

--- a/python/apsis/jobs.py
+++ b/python/apsis/jobs.py
@@ -257,11 +257,11 @@ async def load_jobs_dir(path):
                 exc.job_id = job_id
                 return job_id, None, exc
 
-    load_tasks = [
+    load_coros = [
         load_job(path, job_id)
         for path, job_id in list_yaml_files(jobs_path)
     ]
-    results = await asyncio.gather(*load_tasks)
+    results = await asyncio.gather(*load_coros)
     for job_id, job, exc in results:
         if job is not None:
             jobs[job_id] = job

--- a/python/apsis/service/main.py
+++ b/python/apsis/service/main.py
@@ -74,7 +74,7 @@ def build_apsis(cfg):
     job_dir = cfg["job_dir"]
     log.info(f"opening jobs dir {job_dir}")
     try:
-        jobs = load_jobs_dir(job_dir)
+        jobs = asyncio.get_event_loop().run_until_complete(load_jobs_dir(job_dir))
     except JobsDirErrors as exc:
         for err in exc.errors:
             log.error(f"job {err.job_id}: {err}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+aiofiles
 aiohttp
 brotli
 httpx


### PR DESCRIPTION
This should fix the `woke up late` that we have experienced recently.

Tested on a local instance of Apsis that:
- Apsis startup works fine
- `apsisctl reload-jobs` works fine
- Apsis doesn't freeze anymore while loading jobs