### PR TITLE
Increase threshold2 to 100

### DIFF
--- a/python/apsis/ctl.py
+++ b/python/apsis/ctl.py
@@ -4,7 +4,7 @@ Control CLI, for maintenance and running the service.
 
 # Configure GC as early as possible.
 import gc
-gc.set_threshold(100_000, 100, 10)
+gc.set_threshold(100_000, 100, 100)
 import apsis.lib.py
 apsis.lib.py.track_gc_stats(warn_time=0.5)
 


### PR DESCRIPTION
Temporary hack to reduce probability of unexpected GC pauses. This should reduce the number of gen2 collections by a factor of 10, which is less than once a week for our current activity pattern.