### PR TITLE
Fix `async` stats by aggregating values

### DIFF
--- a/python/apsis/scheduled.py
+++ b/python/apsis/scheduled.py
@@ -26,7 +26,7 @@ async def sleep_until(time):
         late = now() - time
         if late < -0.005:
             log.error(f"woke up early: {-late:.3f} s")
-        elif late > 0.1:
+        elif late > 1:
             log.error(f"woke up late: {late:.1f} s")
 
 


### PR DESCRIPTION
Currently, `__check_async` overwrites the `async` stats every 10 seconds, completely ignoring how often the [`StatsProgram`](https://github.com/apsis-scheduler/apsis/blob/7d39d0bcade0e0e305d0704f4b555500190b9cc9/python/apsis/program/internal/stats.py#L14) is run (i.e. when [`apsis.get_stats`](https://github.com/apsis-scheduler/apsis/blob/7d39d0bcade0e0e305d0704f4b555500190b9cc9/python/apsis/apsis.py#L686) is invoked)

With this change we would instead:
- store latency values in between different executions of `StatsProgram`;
- aggregate those values into stats like `max` (probably most interesting one), `min`, and `avg` when `StatsProgram` is run and clear the latency values stored.

Tested with a local instance of Apsis:
- run `StatsProgram` every 30 sec
- added a `async def random_delay` to simulate event loops pauses

```
{"start_time": "2025-02-18T17:29:07.35578259+00:00", "time": "2025-02-18T17:29:32.7559342+00:00", "async": {"latency_count": 3, "latency_min": 1.2270291149616241, "latency_max": 2.9140290021896362, "latency_avg": 2.2987320919831595, "num_tasks": 11}, "rusage_maxrss": 242049024, "rusage_utime": 2.6487119999999997, "rusage_stime": 0.20285999999999998, "tasks": {"num_waiting": 0, "num_running": 1, "num_stopping": 0, "num_action": 0}, "len_runlogdb_cache": 2885, "scheduled": {"num_heap": 2885, "num_entries": 2885}, "run_store": {"num_runs": 2974, "publisher": {"num_subs": 0, "len_queues": 0}}, "outputs": {"num_cached": 0}, "summary_publisher": {"num_subs": 1, "len_queues": 1}, "gc": [{"collections": 95, "collected": 1115, "uncollectable": 0, "elapsed": 0.06547749898163602, "elapsed_max": 0.026493925019167364}, {"collections": 8, "collected": 213, "uncollectable": 0, "elapsed": 0, "elapsed_max": 0}, {"collections": 0, "collected": 0, "uncollectable": 0, "elapsed": 0, "elapsed_max": 0}], "statm_size": 2551005184, "statm_resident": 240185344}
{"start_time": "2025-02-18T17:29:07.35578259+00:00", "time": "2025-02-18T17:30:00.13724905+00:00", "async": {"latency_count": 3, "latency_min": 0.13644817471504211, "latency_max": 1.255150467157364, "latency_avg": 0.6118734379609426, "num_tasks": 11}, "rusage_maxrss": 242049024, "rusage_utime": 2.683713, "rusage_stime": 0.20693999999999999, "tasks": {"num_waiting": 0, "num_running": 1, "num_stopping": 0, "num_action": 0}, "len_runlogdb_cache": 2884, "scheduled": {"num_heap": 2884, "num_entries": 2884}, "run_store": {"num_runs": 2974, "publisher": {"num_subs": 0, "len_queues": 0}}, "outputs": {"num_cached": 0}, "summary_publisher": {"num_subs": 1, "len_queues": 1}, "gc": [{"collections": 95, "collected": 1115, "uncollectable": 0, "elapsed": 0.06547749898163602, "elapsed_max": 0.026493925019167364}, {"collections": 8, "collected": 213, "uncollectable": 0, "elapsed": 0, "elapsed_max": 0}, {"collections": 0, "collected": 0, "uncollectable": 0, "elapsed": 0, "elapsed_max": 0}], "statm_size": 2551005184, "statm_resident": 240185344}
{"start_time": "2025-02-18T17:29:07.35578259+00:00", "time": "2025-02-18T17:30:31.89178135+00:00", "async": {"latency_count": 3, "latency_min": 0.9071706235408783, "latency_max": 3.300319731235504, "latency_avg": 2.0328408082326255, "num_tasks": 11}, "rusage_maxrss": 242049024, "rusage_utime": 2.720169, "rusage_stime": 0.212394, "tasks": {"num_waiting": 0, "num_running": 1, "num_stopping": 0, "num_action": 0}, "len_runlogdb_cache": 2885, "scheduled": {"num_heap": 2885, "num_entries": 2885}, "run_store": {"num_runs": 2976, "publisher": {"num_subs": 0, "len_queues": 0}}, "outputs": {"num_cached": 0}, "summary_publisher": {"num_subs": 1, "len_queues": 1}, "gc": [{"collections": 95, "collected": 1115, "uncollectable": 0, "elapsed": 0.06547749898163602, "elapsed_max": 0.026493925019167364}, {"collections": 8, "collected": 213, "uncollectable": 0, "elapsed": 0, "elapsed_max": 0}, {"collections": 0, "collected": 0, "uncollectable": 0, "elapsed": 0, "elapsed_max": 0}], "statm_size": 2551005184, "statm_resident": 240185344}
{"start_time": "2025-02-18T17:29:07.35578259+00:00", "time": "2025-02-18T17:31:00.45493733+00:00", "async": {"latency_count": 3, "latency_min": 0.28713586926460266, "latency_max": 2.490171194076538, "latency_avg": 1.077161322037379, "num_tasks": 11}, "rusage_maxrss": 242049024, "rusage_utime": 2.759176, "rusage_stime": 0.21451199999999998, "tasks": {"num_waiting": 0, "num_running": 1, "num_stopping": 0, "num_action": 0}, "len_runlogdb_cache": 2884, "scheduled": {"num_heap": 2884, "num_entries": 2884}, "run_store": {"num_runs": 2976, "publisher": {"num_subs": 0, "len_queues": 0}}, "outputs": {"num_cached": 0}, "summary_publisher": {"num_subs": 1, "len_queues": 1}, "gc": [{"collections": 95, "collected": 1115, "uncollectable": 0, "elapsed": 0.06547749898163602, "elapsed_max": 0.026493925019167364}, {"collections": 8, "collected": 213, "uncollectable": 0, "elapsed": 0, "elapsed_max": 0}, {"collections": 0, "collected": 0, "uncollectable": 0, "elapsed": 0, "elapsed_max": 0}], "statm_size": 2551005184, "statm_resident": 240185344}

```