### PR TITLE
Fix invocations to async func `load_jobs_dir`

### DIFF
--- a/python/apsis/ctl.py
+++ b/python/apsis/ctl.py
@@ -8,6 +8,7 @@ gc.set_threshold(100_000, 100, 100)
 import apsis.lib.py
 apsis.lib.py.track_gc_stats(warn_time=0.5)
 
+import asyncio
 import logging
 import os
 from   pathlib import Path
@@ -71,7 +72,7 @@ def main():
         jobs_dir = None
 
         try:
-            jobs_dir = apsis.jobs.load_jobs_dir(args.path)
+            jobs_dir = asyncio.run(apsis.jobs.load_jobs_dir(args.path))
         except NotADirectoryError as exc:
             parser.error(exc)
         except JobsDirErrors as exc:

--- a/scripts/graph-dependencies.py
+++ b/scripts/graph-dependencies.py
@@ -1,6 +1,7 @@
 # Requires graphviz and graphviz Python module.
 
 import argparse
+import asyncio
 import graphviz
 from   pathlib import Path
 
@@ -20,7 +21,8 @@ parser.add_argument(
 args = parser.parse_args()
 
 # Load all jobs.
-jobs = load_jobs_dir(args.path).get_jobs()
+jobs_dir = asyncio.run(load_jobs_dir(args.path))
+jobs = jobs_dir.get_jobs()
 
 dot = graphviz.Digraph(
     graph_attr={


### PR DESCRIPTION
- Follow up PR to https://github.com/apsis-scheduler/apsis/pull/443, in which we changed `load_jobs_dir` into an `async` function.

cc @gusostow 