### PR TITLE
Bugfix: use renamed CLI argument

### DIFF
--- a/python/apsis/cli.py
+++ b/python/apsis/cli.py
@@ -147,7 +147,7 @@ def main():
     #--- command: output ---------------------------------------------
 
     def cmd_output(client, args):
-        if args.follow or args.tail:
+        if args.follow or args.follow_new:
             async def follow():
                 async with client.get_output_data_updates(
                         args.run_id, "output",


### PR DESCRIPTION
Fixes 
```py
$ apsis output r7576780
Traceback (most recent call last):
  File "/space/asd/conda7/envs/prod7/bin/apsis", line 10, in <module>
    sys.exit(main())
  File "/lib/python3.10/site-packages/apsis/cli.py", line 430, in main
    args.cmd(client, args)
  File "/lib/python3.10/site-packages/apsis/cli.py", line 150, in cmd_output
    if args.follow or args.tail:
AttributeError: 'Namespace' object has no attribute 'tail'
```