### PR TITLE
Use default GC settings

### DIFF
--- a/python/apsis/ctl.py
+++ b/python/apsis/ctl.py
@@ -2,9 +2,6 @@
 Control CLI, for maintenance and running the service.
 """
 
-# Configure GC as early as possible.
-import gc
-gc.set_threshold(100_000, 100, 100)
 import apsis.lib.py
 apsis.lib.py.track_gc_stats(warn_time=0.5)
 

--- a/python/apsis/ctl.py
+++ b/python/apsis/ctl.py
@@ -6,6 +6,7 @@ import apsis.lib.py
 apsis.lib.py.track_gc_stats(warn_time=0.5)
 
 import asyncio
+import gc
 import logging
 import os
 from   pathlib import Path


### PR DESCRIPTION
Now that we know more about the problem, I believe we're more likely to shoot ourselves in the foot by running less often.

I should note that we did get one extended GC pause with default settings, if I'm remembering correctly. I'm hoping that moving to overpowered physical machine with less swapping will help us avoid that in the future.