### PR TITLE
Prevent DST transition to cause infinite loop

### DIFF
--- a/python/apsis/schedule/daily.py
+++ b/python/apsis/schedule/daily.py
@@ -82,15 +82,15 @@ class DailySchedule(Schedule):
                     "skipping nonexistent schedule time "
                     f"{sched_date} {daytime} {self.tz}"
                 )
-                continue
-            assert time >= start
-            args = {
-                "date": str(date),
-                "time": time,
-                "daytime": str(daytime),
-                **common_args,
-            }
-            yield time, args
+            else:
+                assert time >= start
+                args = {
+                    "date": str(date),
+                    "time": time,
+                    "daytime": str(daytime),
+                    **common_args,
+                }
+                yield time, args
 
             i += 1
             if i == len(self.daytimes):


### PR DESCRIPTION
I was able to reproduce the issue we had this morning with a local instance on Apsis.
```
2025-03-07T18:29:34.917 apsis.schedule.daily     W skipping nonexistent schedule time 2025-03-09 02:30:00 America/New_York
2025-03-07T18:29:34.917 apsis.schedule.daily     W skipping nonexistent schedule time 2025-03-09 02:30:00 America/New_York
2025-03-07T18:29:34.917 apsis.schedule.daily     W skipping nonexistent schedule time 2025-03-09 02:30:00 America/New_York
2025-03-07T18:29:34.917 apsis.schedule.daily     W skipping nonexistent schedule time 2025-03-09 02:30:00 America/New_York
2025-03-07T18:29:34.917 apsis.schedule.daily     W skipping nonexistent schedule time 2025-03-09 02:30:00 America/New_York
2025-03-07T18:29:34.917 apsis.schedule.daily     W skipping nonexistent schedule time 2025-03-09 02:30:00 America/New_York
2025-03-07T18:29:34.917 apsis.schedule.daily     W skipping nonexistent schedule time 2025-03-09 02:30:00 America/New_York
2025-03-07T18:29:34.917 apsis.schedule.daily     W skipping nonexistent schedule time 2025-03-09 02:30:00 America/New_York
2025-03-07T18:29:34.917 apsis.schedule.daily     W skipping nonexistent schedule time 2025-03-09 02:30:00 America/New_York
2025-03-07T18:29:34.917 apsis.schedule.daily     W skipping nonexistent schedule time 2025-03-09 02:30:00 America/New_York
2025-03-07T18:29:34.917 apsis.schedule.daily     W skipping nonexistent schedule time 2025-03-09 02:30:00 America/New_York
2025-03-07T18:29:34.918 apsis.schedule.daily     W skipping nonexistent schedule time 2025-03-09 02:30:00 America/New_York
```
This is the job def I used to reproduce the issue:
```
✦5 x cat few_jobs/offending.yaml

params: [date]

program:
  type: asd.lib.ops.apsis.program.ProcstarProgram
  argv:
    - /usr/bin/sleep
    - 10
  group_id: my-group

schedule:
  type: daily
  tz: America/New_York
  calendar: ALLDAYS
  daytime: 02:00:00

condition:
  type: max_running
  count: 1
```

--------------------------------------------

After the fix this works fine.

Notice this will skip the runs that fall into the DST transitions. I'll then probably introduce a check to prevent ambiguous schedules to be used at all, or consider other way to handle this scenarios.