### PR TITLE
Bugfix: don't print unrelated job_id in `apsisctl check-jobs`

### DIFF
--- a/python/apsis/jobs.py
+++ b/python/apsis/jobs.py
@@ -271,7 +271,7 @@ async def load_jobs_dir(path):
     for job in jobs_dir.get_jobs():
         log.info(f"checking: {job.job_id}")
         for err in check_job(jobs_dir, job):
-            errors.append(JobError(job_id, f"{job.job_id}: {err}"))
+            errors.append(JobError(job.job_id, str(err)))
 
     if len(errors) > 0:
         raise JobsDirErrors(f"errors loading jobs in {jobs_path}", errors)


### PR DESCRIPTION
- Fixes https://github.com/apsis-scheduler/apsis/issues/462


