### PR TITLE
Change dir to `sudo_user` home dir when sudoing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "brotli",
     "httpx",
     "jinja2",
-    "ora",
+    "ora <0.9.0",
     "procstar >=0.4",
     "pyyaml",
     "requests",

--- a/python/apsis/program/procstar/agent.py
+++ b/python/apsis/program/procstar/agent.py
@@ -3,6 +3,7 @@ import logging
 import procstar.spec
 from   procstar.agent.exc import NoConnectionError, NoOpenConnectionInGroup, ProcessUnknownError
 from   procstar.agent.proc import FdData, Interval, Result
+import pwd
 from   signal import Signals
 import uuid
 
@@ -35,6 +36,7 @@ def _sudo_wrap(cfg, argv, sudo_user):
         return [ str(a) for a in sudo_argv ] + [
             "--non-interactive",
             "--user", str(sudo_user),
+            "--chdir", pwd.getpwnam(sudo_user).pw_dir,
             "--"
         ] + list(argv)
 

--- a/python/apsis/program/procstar/agent.py
+++ b/python/apsis/program/procstar/agent.py
@@ -3,7 +3,6 @@ import logging
 import procstar.spec
 from   procstar.agent.exc import NoConnectionError, NoOpenConnectionInGroup, ProcessUnknownError
 from   procstar.agent.proc import FdData, Interval, Result
-import pwd
 from   signal import Signals
 import uuid
 
@@ -36,7 +35,7 @@ def _sudo_wrap(cfg, argv, sudo_user):
         return [ str(a) for a in sudo_argv ] + [
             "--non-interactive",
             "--user", str(sudo_user),
-            "--chdir", pwd.getpwnam(sudo_user).pw_dir,
+            "--chdir", f"/home/{sudo_user}",
             "--"
         ] + list(argv)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ aiohttp
 brotli
 httpx
 jinja2
-ora
+ora <0.9.0
 pyyaml
 requests
 rich

--- a/test/int/procstar/mock_sudo
+++ b/test/int/procstar/mock_sudo
@@ -13,6 +13,7 @@ parser.add_argument("--preserve-env", "-E", default=False, action="store_true")
 parser.add_argument("--set-home", "-H", default=False, action="store_true")
 parser.add_argument("--non-interactive", "-n", default=False, action="store_true")
 parser.add_argument("--user", "-u")
+parser.add_argument("--chdir", "-D")
 parser.add_argument("argv", nargs="+")
 args = parser.parse_args()
 


### PR DESCRIPTION
By default, when sudo-ing without `--login` flag, the working dir is left unchanged.

With this change we're setting it to `sudo_user`'s home dir.

```
> sudo --help | grep chdir
  -D, --chdir=directory         change the working directory before running command
```

Tested with a local instance of Apsis.


-------------------------------

Notice I had to add the `<0.9.0` constraint for `ora`, as the CI build was failing otherwise:
- https://github.com/apsis-scheduler/apsis/actions/runs/15463567053/job/43531334099
```
build/temp.linux-x86_64-cpython-310/python/ora/ext/functions.o -std=c++17 -fdiagnostics-color=always -Wno-dangling-else
      In file included from python/ora/ext/functions.cc:6:
      python/ora/ext/py.hh: In member function ‘ora::py::Long::operator __int128()’:
      python/ora/ext/py.hh:700:42: error: too many arguments to function ‘int _PyLong_AsByteArray(PyLongObject*, unsigned char*, size_t, int, int)’
        700 |   check_not_minus_one(_PyLong_AsByteArray(
            |                       ~~~~~~~~~~~~~~~~~~~^
        701 |     (PyLongObject*) this, (unsigned char*) &val, sizeof(val), 1, 1, 1));
            |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      In file included from /opt/hostedtoolcache/Python/3.10.17/x64/include/python3.10/Python.h:84,
                       from python/ora/ext/py.hh:11:
      /opt/hostedtoolcache/Python/3.10.17/x64/include/python3.10/longobject.h:170:17: note: declared here
        170 | PyAPI_FUNC(int) _PyLong_AsByteArray(PyLongObject* v,
            |                 ^~~~~~~~~~~~~~~~~~~
      python/ora/ext/py.hh: In member function ‘ora::py::Long::operator __int128 unsigned()’:
      python/ora/ext/py.hh:710:42: error: too many arguments to function ‘int _PyLong_AsByteArray(PyLongObject*, unsigned char*, size_t, int, int)’
        710 |   check_not_minus_one(_PyLong_AsByteArray(
            |                       ~~~~~~~~~~~~~~~~~~~^
        711 |     (PyLongObject*) this, (unsigned char*) &val, sizeof(val), 1, 0, 1));
            |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      /opt/hostedtoolcache/Python/3.10.17/x64/include/python3.10/longobject.h:170:17: note: declared here
        170 | PyAPI_FUNC(int) _PyLong_AsByteArray(PyLongObject* v,
            |                 ^~~~~~~~~~~~~~~~~~~
      error: command '/usr/bin/g++' failed with exit code 1
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for ora
ERROR: Failed to build installable wheels for some pyproject.toml based projects (ora)
Successfully built apsis
Failed to build ora
```
