### PR TITLE
Fix race condition: handle already completed processes

### DIFF
--- a/python/apsis/program/procstar/agent.py
+++ b/python/apsis/program/procstar/agent.py
@@ -455,7 +455,6 @@ class RunningProcstarProgram(base.RunningProgram):
                         await asyncio.sleep(sleep_duration)
 
                     if not self.stopping and self.proc is not None:
-                        elapsed = ora.now() - start
                         log.info(f"{self.run_id}: timeout")
                         self.timed_out = True
                         timeout_signal = Signals[self.program.timeout.signal]

--- a/python/apsis/program/procstar/agent.py
+++ b/python/apsis/program/procstar/agent.py
@@ -544,7 +544,7 @@ class RunningProcstarProgram(base.RunningProgram):
             outputs = await _make_outputs(fd_data)
             meta["stop"] = {"signals": [ s.name for s in self.stop_signals ]}
 
-            if res.status.exit_code == 0 and res.status.signal is None:
+            if res.status.exit_code == 0 and not self.timed_out:
                 # The process terminated successfully.
                 yield ProgramSuccess(meta=meta, outputs=outputs)
             elif (

--- a/test/int/procstar/jobs/timeout-failure.yaml
+++ b/test/int/procstar/jobs/timeout-failure.yaml
@@ -1,0 +1,8 @@
+params: ["timeout", "sleep_duration"]
+
+program:
+  type: procstar-shell
+  command: "/usr/bin/sleep {{ sleep_duration }} && wrong_command_to_make_it_fail"
+  timeout:
+    duration: "{{ timeout }}"
+    signal: "SIGTERM"

--- a/test/int/procstar/jobs/timeout-handle-sigterm.yaml
+++ b/test/int/procstar/jobs/timeout-handle-sigterm.yaml
@@ -1,0 +1,8 @@
+params: ["timeout", "sleep_duration"]
+
+program:
+  type: procstar-shell
+  command: "trap 'exit 0' SIGTERM; sleep {{ sleep_duration }}"
+  timeout:
+    duration: "{{ timeout }}"
+    signal: "SIGTERM"

--- a/test/int/procstar/test_timeout.py
+++ b/test/int/procstar/test_timeout.py
@@ -151,3 +151,41 @@ def test_timeout_with_delayed_reconnect(job_name):
         assert (
             abs(actual_elapsed - downtime) <= tolerance
         ), f"Elapsed time {actual_elapsed:.3f}s should be close to downtime {downtime}s (tolerance: {tolerance}s). Run should have been killed shortly after Apsis reconnected."
+
+
+@pytest.mark.parametrize(
+    "job_name,expected_state",
+    [
+        ("timeout", "success"),
+        ("timeout-shell", "success"),
+        ("timeout-failure", "failure"),
+    ],
+)
+def test_timeout_with_delayed_reconnect_process_completed(job_name, expected_state):
+    """
+    Tests that when Apsis is down long enough for a process to complete naturally,
+    the race condition is handled gracefully and the run gets the expected final state.
+    """
+    with ApsisService(job_dir=JOB_DIR) as svc, svc.agent(serve=True):
+        client = svc.client
+        timeout = 1.5
+        sleep_duration = 2
+        run_id = client.schedule(
+            job_name, {"timeout": timeout, "sleep_duration": sleep_duration}
+        )["run_id"]
+
+        res = svc.wait_run(run_id, wait_states=("starting",))
+        assert res["state"] == "running"
+
+        # Stop Apsis for long enough to let the process complete naturally
+        svc.stop_serve()
+        downtime = 3
+        sleep(downtime)
+        svc.start_serve()
+        svc.wait_for_serve()
+
+        # Wait for the run to complete
+        res = svc.wait_run(run_id, timeout=sleep_duration + 1)
+
+        # Assert the expected final state
+        assert res["state"] == expected_state

--- a/test/int/procstar/test_timeout.py
+++ b/test/int/procstar/test_timeout.py
@@ -7,7 +7,7 @@ from procstar_instance import ApsisService
 JOB_DIR = Path(__file__).parent / "jobs"
 
 
-@pytest.mark.parametrize("job_name", ["timeout", "timeout-shell"])
+@pytest.mark.parametrize("job_name", ["timeout", "timeout-shell", "timeout-handle-sigterm"])
 def test_timeout(job_name):
     """
     Tests agent program timeout.


### PR DESCRIPTION
While I was doing some final testing, I noticed this race condition. (See `timeout1` job runs in Apsis).
```
2025-06-24T14:22:14.454 apsis.program.procstar.agent E procstar
Traceback (most recent call last):
  File "/home/lrighi/apsis/python/apsis/program/procstar/agent.py", line 532, in updates
    async for update in self.proc.updates:
  File "/space/asd/conda7/envs/prod7-20250624-009/lib/python3.10/site-packages/procstar/agent/proc.py", line 155, in updates
    raise AgentMessageError(msg, err)
procstar.agent.proc.AgentMessageError: agent error response to message: no process
2025-06-24T14:22:14.454 apsis.run_log            I r2: error: procstar: agent error response to message: no process
```

I've added another test for this:
#### without the change
```
FAILED test/int/procstar/test_timeout.py::test_timeout_with_delayed_reconnect_process_completed[timeout-success] - AssertionError: assert 'failure' == 'success'
  
  - success
  + failure
FAILED test/int/procstar/test_timeout.py::test_timeout_with_delayed_reconnect_process_completed[timeout-shell-success] - AssertionError: assert 'failure' == 'success'
  
  - success
  + failure
FAILED test/int/procstar/test_timeout.py::test_timeout_with_delayed_reconnect_process_completed[timeout-error-failure] - AssertionError: assert 'error' == 'failure'
  
  - failure
  + error
```

#### with the change:
```
test/int/procstar/test_timeout.py::test_timeout_with_delayed_reconnect_process_completed[timeout-success] PASSED                        [ 33%]
test/int/procstar/test_timeout.py::test_timeout_with_delayed_reconnect_process_completed[timeout-shell-success] PASSED                  [ 66%]
test/int/procstar/test_timeout.py::test_timeout_with_delayed_reconnect_process_completed[timeout-error-failure] PASSED                  [100%]
```
