### PR TITLE
Reduce likelihood of timeout/signal related race condition

### DIFF
--- a/python/apsis/program/procstar/agent.py
+++ b/python/apsis/program/procstar/agent.py
@@ -477,7 +477,6 @@ class RunningProcstarProgram(base.RunningProgram):
                         await asyncio.sleep(sleep_duration)
 
                     if not self.stopping and self.proc is not None:
-                        elapsed = ora.now() - start
                         log.info(f"{self.run_id}: timeout")
                         self.timed_out = True
                         timeout_signal = Signals[self.program.timeout.signal]

--- a/python/apsis/program/procstar/agent.py
+++ b/python/apsis/program/procstar/agent.py
@@ -477,6 +477,9 @@ class RunningProcstarProgram(base.RunningProgram):
                         await asyncio.sleep(sleep_duration)
 
                     if not self.stopping and self.proc is not None:
+                        # Introduce a small delay to allow updates to arrive in case Apsis and Procstar just reconnected.
+                        # If the process already terminated, the timeout task will be cancelled.
+                        await asyncio.sleep(0.01)
                         log.info(f"{self.run_id}: timeout")
                         self.timed_out = True
                         timeout_signal = Signals[self.program.timeout.signal]
@@ -522,6 +525,13 @@ class RunningProcstarProgram(base.RunningProgram):
                             yield base.ProgramUpdate(meta=meta)
                         else:
                             # Process terminated.
+                            if res.state == "terminated":
+                                try:
+                                    # cancel timeout task as soon as possible, if any
+                                    await tasks.cancel("timeout")
+                                    log.info(f"{self.run_id}: cancelled timeout task as process already terminated.")
+                                except KeyError:
+                                    pass
                             break
 
             else:

--- a/test/int/procstar/jobs/timeout-failure.yaml
+++ b/test/int/procstar/jobs/timeout-failure.yaml
@@ -1,0 +1,8 @@
+params: ["timeout", "sleep_duration"]
+
+program:
+  type: procstar-shell
+  command: "/usr/bin/sleep {{ sleep_duration }} && wrong_cmd_to_make_it_fail"
+  timeout:
+    duration: "{{ timeout }}"
+    signal: "SIGTERM"

--- a/test/int/procstar/jobs/timeout-handle-sigterm.yaml
+++ b/test/int/procstar/jobs/timeout-handle-sigterm.yaml
@@ -1,0 +1,8 @@
+params: ["timeout", "sleep_duration"]
+
+program:
+  type: procstar-shell
+  command: "trap 'exit 0' SIGTERM; sleep {{ sleep_duration }}"
+  timeout:
+    duration: "{{ timeout }}"
+    signal: "SIGTERM"

--- a/test/int/procstar/test_timeout.py
+++ b/test/int/procstar/test_timeout.py
@@ -7,7 +7,9 @@ from procstar_instance import ApsisService
 JOB_DIR = Path(__file__).parent / "jobs"
 
 
-@pytest.mark.parametrize("job_name", ["timeout", "timeout-shell"])
+@pytest.mark.parametrize(
+    "job_name", ["timeout", "timeout-shell", "timeout-handle-sigterm"]
+)
 def test_timeout(job_name):
     """
     Tests agent program timeout.

--- a/test/int/procstar/test_timeout.py
+++ b/test/int/procstar/test_timeout.py
@@ -153,3 +153,45 @@ def test_timeout_with_delayed_reconnect(job_name):
         assert (
             abs(actual_elapsed - downtime) <= tolerance
         ), f"Elapsed time {actual_elapsed:.3f}s should be close to downtime {downtime}s (tolerance: {tolerance}s). Run should have been killed shortly after Apsis reconnected."
+
+
+@pytest.mark.parametrize(
+    "job_name,expected_state",
+    [
+        ("timeout", "success"),
+        ("timeout-shell", "success"),
+        ("timeout-failure", "failure"),
+    ],
+)
+def test_timeout_with_delayed_reconnect_process_terminated(job_name, expected_state):
+    """
+    Tests that the timeout signal is not sent if the process already terminated
+    while Apsis was restarting.
+    """
+    with ApsisService(job_dir=JOB_DIR) as svc, svc.agent(serve=True):
+        client = svc.client
+        timeout = 1
+        sleep_duration = 2
+        run_id = client.schedule(
+            job_name, {"timeout": timeout, "sleep_duration": sleep_duration}
+        )["run_id"]
+
+        # Start a run that will terminate while Apsis is restarting
+        res = svc.wait_run(run_id, wait_states=("starting",))
+        assert res["state"] == "running"
+
+        # Stop Apsis for longer than the run duration
+        svc.stop_serve()
+        downtime = 3
+        sleep(downtime)
+        svc.start_serve()
+        svc.wait_for_serve()
+
+        res = svc.wait_run(run_id, wait_states="running", timeout=sleep_duration + 1)
+        assert res["state"] == expected_state
+
+        # ensure no stop signal was sent
+        assert res["meta"]["program"]["stop"]["signals"] == []
+
+        run_log = svc.client.get_run_log(run_id)
+        assert "timeout" not in run_log[-1]["message"]


### PR DESCRIPTION
Summary: there is a race condition (i.e. trying to send a signal to a process which doesn't exist anymore) in Procstar; this PR helps to make that race less likely, but won't fix it completely. More details below.

-------------------
#### The race condition

- To me, it looks like there is a race condition in Procstar, i.e. we may try to send a signal to a process that don't exist anymore, which [results in a `AgentMessageError: agent error response to message: no process`.](https://github.com/apsis-scheduler/procstar/blob/e789b0a7a6838902bb3aa386e72fcd3210308b10/python/procstar/agent/proc.py#L153-L155).
  - see the [`kill` function](https://github.com/apsis-scheduler/procstar/blob/e789b0a7a6838902bb3aa386e72fcd3210308b10/src/sys.rs#L332-L346) 
    - _ESRCH=The target process or process group does not exist.  Note that an existing process might be a zombie, a process that has terminated execution, but has not yet been [wait(2)](https://man7.org/linux/man-pages/man2/wait.2.html)ed for. No such process from man (from [kill man](https://man7.org/linux/man-pages/man2/kill.2.html))_

  - I think this race condition could be fixed by using a locking mechanism between:
    - [`wait_for_proc`](https://github.com/apsis-scheduler/procstar/blob/e789b0a7a6838902bb3aa386e72fcd3210308b10/src/procs.rs#L485-L525)
    - [`send_signal`](https://github.com/apsis-scheduler/procstar/blob/e789b0a7a6838902bb3aa386e72fcd3210308b10/src/procs.rs#L80-L89) (or maybe `kill` function itself)

  - Ideally, rather than blindly trying to send the signal and then erroring with `no process`, we should rather ensure the process is still around before sending the signal and only log something like `process already terminated: not sending the signal`.
(Not sure if there's also the risk that we kill another process which may have started with the same PID, haven't double checked yet).

-----------------
#### The change

The idea of this change is to cancel the timeout task as soon as the update regarding the process termination is received. 
This should help to reduce the likelihood of the issue explained above:
 - in particular, this helps in the case in which a run has already terminated during a disconnection period
   - as soon as Apsis and Procstar reconnect, Apsis would receive a process update that we can use to decide whether to cancel the timeout or not.

---------------------
#### Issue reproduction:

Notice that running the test I've added against `master` branch helps to reproduce the `AgentMessageError` consistently.
```
> pytest test/int/procstar/test_timeout.py::test_timeout_with_delayed_reconnect_process_terminated['timeout-failure-failure'] -s -vv
(...)
2025-07-10T12:50:07.133 apsis.program.procstar.agent I reconnected: 1e8e1a45-e79c-4c5d-910a-a7e00b7b7ea9 on conn 86f1a7dc-b136-40f3-a666-3c8b94de2582
2025-07-10T12:50:07.133 apsis.program.procstar.agent I r1: timeout
2025-07-10T12:50:07.134 procstar.agent.proc      E agent error: no process
2025-07-10T12:50:07.135 apsis.program.procstar.agent E procstar
Traceback (most recent call last):
  File "/space/asd/conda7/envs/prod7-20250710-006/lib/python3.10/site-packages/apsis/program/procstar/agent.py", line 550, in updates
    fd_data = await asyncio.wait_for(
  File "/space/asd/conda7/envs/prod7-20250710-006/lib/python3.10/asyncio/tasks.py", line 445, in wait_for
    return fut.result()
  File "/space/asd/conda7/envs/prod7-20250710-006/lib/python3.10/site-packages/apsis/program/procstar/agent.py", line 326, in collect_final_fd_data
    async for update in proc.updates:
  File "/space/asd/conda7/envs/prod7-20250710-006/lib/python3.10/site-packages/procstar/agent/proc.py", line 155, in updates
    raise AgentMessageError(msg, err)
procstar.agent.proc.AgentMessageError: agent error response to message: no process
2025-07-10T12:50:07.135 apsis.run_log            I r1: error: procstar: agent error response to message: no process
2025-07-10T12:50:07.175 apsis.service.main       E caught SIGTERM
2025-07-10T12:50:07.175 apsis.service.main       I task cancelled with return: restore
2025-07-10T12:50:07.175 apsis.service.main       I task cancelled with return: Sanic
2025-07-10T12:50:07.175 apsis.apsis              I shutting down Apsis
2025-07-10T12:50:07.175 apsis.apsis              I task cancelled with CancelledError: check_async
2025-07-10T12:50:07.176 procstar.agent.server    W closed: 86f1a7dc-b136-40f3-a666-3c8b94de2582: no close frame received or sent
(...)

=============================================================================================================================== short test summary info ===============================================================================================================================
FAILED test/int/procstar/test_timeout.py::test_timeout_with_delayed_reconnect_process_terminated[timeout-failure-failure] - AssertionError: assert 'error' == 'failure'
  
  - failure
  + error
============================================================================================================================ 1 failed, 4 warnings in 5.21s ============================
```

- (Closed https://github.com/apsis-scheduler/apsis/pull/470 in favor of this PR)