### PR TITLE
Bugfix: append traceback to existing output for errored runs

### DIFF
--- a/python/apsis/running.py
+++ b/python/apsis/running.py
@@ -175,7 +175,7 @@ async def _process_updates(apsis, run):
             # no output yet
             pass
         data = (existing_output.data if existing_output else b"") + tb
-        output = Output(OutputMetadata("output", length=len(data)), data)
+        output = Output(OutputMetadata("combined stdout & stderr", length=len(data)), data)
         apsis._update_output_data(run, {"output": output}, True)
         apsis._transition(run, State.error, force=True)
 

--- a/python/apsis/running.py
+++ b/python/apsis/running.py
@@ -168,7 +168,14 @@ async def _process_updates(apsis, run):
         # Program raised some other exception.
         apsis.run_log.exc(run, "error: internal")
         tb = traceback.format_exc().encode()
-        output = Output(OutputMetadata("traceback", length=len(tb)), tb)
+        existing_output = None
+        try:
+            existing_output = apsis.outputs.get_output(run.run_id, "output")
+        except LookupError as e:
+            # no output yet
+            pass
+        data = (existing_output.data if existing_output else b"") + tb
+        output = Output(OutputMetadata("output", length=len(data)), data)
         apsis._update_output_data(run, {"output": output}, True)
         apsis._transition(run, State.error, force=True)
 

--- a/python/apsis/running.py
+++ b/python/apsis/running.py
@@ -169,7 +169,7 @@ async def _process_updates(apsis, run):
         apsis.run_log.exc(run, "error: internal")
         tb = traceback.format_exc().encode()
         output = Output(OutputMetadata("traceback", length=len(tb)), tb)
-        apsis._update_output_data(run, {"outputs": output}, True)
+        apsis._update_output_data(run, {"output": output}, True)
         apsis._transition(run, State.error, force=True)
 
     finally:


### PR DESCRIPTION
Related note:
https://github.com/apsis-scheduler/apsis/blob/e5f1029c41a3f0a1919e68ad27a29a012c1f364f/python/apsis/apsis.py#L339-L340

--------------------------

Tested this for:
#### runs that produce output
```
output261 bytes
some_output...
some_output...
some_output...
Traceback (most recent call last):
  File "/home/lrighi/apsis/python/apsis/running.py", line 101, in _process_updates
    raise FileNotFoundError("TTTSimulating an issue!")
FileNotFoundError: TTTSimulating an issue!
```
#### runs that don't produce any output
```
output216 bytes
Traceback (most recent call last):
  File "/home/lrighi/apsis/python/apsis/running.py", line 101, in _process_updates
    raise FileNotFoundError("TTTSimulating an issue!")
FileNotFoundError: TTTSimulating an issue!
```



UPDATE: need to review this again; we probably shouldn't mix output and Apsis errors.