### PR TITLE
Mitigate websocket disconnects

### DIFF
--- a/python/apsis/service/api.py
+++ b/python/apsis/service/api.py
@@ -556,7 +556,7 @@ async def websocket_summary(request, ws):
 
         except asyncio.CancelledError:
             # task is cancelled in the event of abnormal websocket closure, usually if
-            # websocket close due to a ping timeout can't complete successfull
+            # websocket close due to a ping timeout can't complete successfully
             log.warning(
                 f"{prefix} task cancelled after {time.monotonic() - connect_time:.2f}s"
             )

--- a/python/apsis/service/main.py
+++ b/python/apsis/service/main.py
@@ -50,6 +50,10 @@ class Router(sanic.router.Router):
 app = sanic.Sanic("apsis", router=Router(), log_config=SANIC_LOG_CONFIG)
 app.config.LOGO = None
 
+# more forgiving for when slow browsers can't keep up with websocket messages
+app.config.WEBSOCKET_PING_TIMEOUT = 300
+app.config.WEBSOCKET_PING_INTERVAL = 100
+
 app.blueprint(api.API, url_prefix="/api/v1")
 app.blueprint(control.API, url_prefix="/api/control")
 app.blueprint(procstar.API, url_prefix="/api/procstar")


### PR DESCRIPTION
The browser isn't reconnecting the summary socket after https://github.com/apsis-scheduler/apsis/pull/471. Disconnects are happening a too often.

The underlying issue is a ping/pong timeout which can't complete when the browser can't keep up with summary messages, closing the TCP receive window. 

I'm hoping that increasing the ping timeouts from 20s -> 300s will give the browser a chance to load the full summary history before getting timed out. Then it will only have to handle incremental updates which are much lighter.