### PR TITLE
Only consider runs which returned zero exit code as successful

### DIFF
--- a/docs/programs.rst
+++ b/docs/programs.rst
@@ -179,9 +179,9 @@ Apsis requests a program to stop if the program's run is configured with a stop
 schedule, or in response to an explicit stop operation invoked by the user.
 
 Before Apsis requests a program to stop, it transitions the run to the
-*stopping* state.  If the program terminates correctly in response to the stop
-request, Apsis transitions the run to *success*; if the program terminates in an
-unexpected way, *failure*.
+*stopping* state.  If the program terminates correctly (zero exit code) in response 
+to the stop request, Apsis transitions the run to *success*; if the program terminates 
+in an unexpected way (non-zero exit code), *failure*.
 
 The program types above that create a UNIX process (`program`, `shell`,
 `procstar`, `procstar-shell`) all implement program stop similarly.  In response
@@ -206,8 +206,8 @@ only wait 15 seconds before sending `SIGKILL`.
             signal: SIGUSR2
             grace_period: 15s
 
-If the program terminates with an exit status that indicates the process ended
-from `SIGUSR2`, Apsis considers the run to have succeeded.
+Only if the process terminates with zero exit code the run will be considered as 
+successfull.
 
 
 Internal Programs

--- a/python/apsis/program/agent.py
+++ b/python/apsis/program/agent.py
@@ -336,16 +336,6 @@ class RunningAgentProgram(RunningProgram):
             try:
                 if status == 0:
                     yield ProgramSuccess(meta=proc, outputs=outputs)
-
-                elif (
-                    self.stopping
-                    and os.WIFSIGNALED(status)
-                    and Signals(os.WTERMSIG(status)) == self.program.stop.signal
-                ):
-                    # Program stopped as expected.
-                    log.info("EXPECTED SIGTERM WHEN STOPPING")
-                    yield ProgramSuccess(meta=proc, outputs=outputs)
-
                 else:
                     message = f"program failed: status {status}{explanation}"
                     yield ProgramFailure(message, meta=proc, outputs=outputs)

--- a/python/apsis/program/process.py
+++ b/python/apsis/program/process.py
@@ -229,15 +229,6 @@ class RunningProcessProgram(RunningProgram):
 
         if return_code == 0:
             yield ProgramSuccess(meta=meta, outputs=outputs)
-
-        elif (
-            self.stopping
-            and self.returncode < 0
-            and Signals(self.returncode) == self.program.stop.signal
-        ):
-            # Program stopped as expected.
-            yield ProgramFailure(meta=meta, outputs=outputs)
-
         else:
             message = f"program failed: return code {return_code}"
             yield ProgramFailure(message, meta=meta, outputs=outputs)

--- a/python/apsis/program/procstar/agent.py
+++ b/python/apsis/program/procstar/agent.py
@@ -634,13 +634,6 @@ class RunningProcstarProgram(base.RunningProgram):
             if res.status.exit_code == 0 and not self.timed_out:
                 # The process terminated successfully.
                 yield ProgramSuccess(meta=meta, outputs=outputs)
-            elif (
-                self.stopping
-                and res.status.signal is not None
-                and Signals[res.status.signal] == self.program.stop.signal
-            ):
-                # The process stopped with the expected signal.
-                yield ProgramSuccess(meta=meta, outputs=outputs)
             else:
                 message = (
                     f"exit code {res.status.exit_code}"

--- a/test/int/basic/test_agent_stop.py
+++ b/test/int/basic/test_agent_stop.py
@@ -15,7 +15,7 @@ def test_stop_basic():
         assert res["state"] == "running"
 
         res = inst.wait_run(run_id)
-        assert res["state"] == "success"
+        assert res["state"] == "failure"
         assert "stopping" in res["times"]
         assert res["meta"]["elapsed"] < 2
 
@@ -36,7 +36,7 @@ def test_stop_api():
         assert res["state"] == "stopping"
 
         res = inst.wait_run(run_id)
-        assert res["state"] == "success"
+        assert res["state"] == "failure"
         assert "stopping" in res["times"]
         assert res["meta"]["elapsed"] < 2
 

--- a/test/int/procstar/exit-one-on-term.py
+++ b/test/int/procstar/exit-one-on-term.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from   argparse import ArgumentParser
+from argparse import ArgumentParser
 import signal
 import time
 import sys
@@ -9,13 +9,14 @@ parser = ArgumentParser()
 parser.add_argument("sleep", metavar="SECS", type=float)
 args = parser.parse_args()
 
+
 def sigterm(signum, frame):
     sig = signal.Signals(signum)
-    print(f"ignoring {sig.name}", file=sys.stderr)
+    sys.exit(1)
+
 
 signal.signal(signal.Signals.SIGTERM, sigterm)
 
 print(f"sleeping for {args.sleep} sec", file=sys.stderr)
 time.sleep(args.sleep)
 print("done", file=sys.stderr)
-

--- a/test/int/procstar/exit-zero-on-term.py
+++ b/test/int/procstar/exit-zero-on-term.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+from argparse import ArgumentParser
+import signal
+import time
+import sys
+
+parser = ArgumentParser()
+parser.add_argument("sleep", metavar="SECS", type=float)
+args = parser.parse_args()
+
+
+def sigterm(signum, frame):
+    sig = signal.Signals(signum)
+    sys.exit(0)
+
+
+signal.signal(signal.Signals.SIGTERM, sigterm)
+
+print(f"sleeping for {args.sleep} sec", file=sys.stderr)
+time.sleep(args.sleep)
+print("done", file=sys.stderr)

--- a/test/int/procstar/ignore-term.py
+++ b/test/int/procstar/ignore-term.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+from argparse import ArgumentParser
+import signal
+import time
+import sys
+
+parser = ArgumentParser()
+parser.add_argument("sleep", metavar="SECS", type=float)
+args = parser.parse_args()
+
+
+def sigterm(signum, frame):
+    sig = signal.Signals(signum)
+    print(f"ignoring {sig.name}", file=sys.stderr)
+
+
+signal.signal(signal.Signals.SIGTERM, sigterm)
+
+print(f"sleeping for {args.sleep} sec", file=sys.stderr)
+time.sleep(args.sleep)
+print("done", file=sys.stderr)

--- a/test/int/procstar/slow-cleanup.py
+++ b/test/int/procstar/slow-cleanup.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+from argparse import ArgumentParser
+import signal
+import time
+import sys
+
+parser = ArgumentParser()
+parser.add_argument("sleep", metavar="SECS", type=float)
+parser.add_argument("--cleanup-time", type=float, default=1.0, help="Time to spend in cleanup")
+args = parser.parse_args()
+
+
+def sigterm_handler(signum, frame):
+    sig = signal.Signals(signum)
+    print(f"received {sig.name}, starting cleanup...")
+
+    # Simulate slow cleanup process
+    cleanup_start = time.time()
+    while time.time() - cleanup_start < args.cleanup_time:
+        print("cleaning up...")
+        time.sleep(0.2)
+
+    print("cleanup complete")
+    sys.exit(0)
+
+
+signal.signal(signal.SIGTERM, sigterm_handler)
+
+print(f"sleeping for {args.sleep} sec")
+time.sleep(args.sleep)
+print("completed normally")

--- a/test/int/procstar/test_stop.py
+++ b/test/int/procstar/test_stop.py
@@ -2,6 +2,8 @@ from ora import Time
 from pathlib import Path
 import time
 
+import pytest
+
 from procstar_instance import ApsisService
 from apsis.jobs import jso_to_job, dump_job
 
@@ -18,7 +20,57 @@ SLEEP_JOB = jso_to_job(
     "sleep",
 )
 
-IGNORE_TERM_PATH = Path(__file__).parent / "ignore-term"
+EXIT_ZERO_ON_TERM_PATH = Path(__file__).parent / "exit-zero-on-term.py"
+EXIT_ZERO_ON_TERM_JOB = jso_to_job(
+    {
+        "params": ["time"],
+        "program": {
+            "type": "procstar",
+            "argv": [EXIT_ZERO_ON_TERM_PATH, "{{ time }}"],
+            "stop": {
+                "grace_period": 2,
+            },
+        },
+    },
+    "exit zero on term",
+)
+
+EXIT_ONE_ON_TERM_PATH = Path(__file__).parent / "exit-one-on-term.py"
+EXIT_ONE_ON_TERM_JOB = jso_to_job(
+    {
+        "params": ["time"],
+        "program": {
+            "type": "procstar",
+            "argv": [EXIT_ONE_ON_TERM_PATH, "{{ time }}"],
+            "stop": {
+                "grace_period": 2,
+            },
+        },
+    },
+    "exit one on term",
+)
+
+SLOW_CLEANUP_PATH = Path(__file__).parent / "slow-cleanup.py"
+SLOW_CLEANUP_JOB = jso_to_job(
+    {
+        "params": ["time", "cleanup_time"],
+        "program": {
+            "type": "procstar",
+            "argv": [
+                SLOW_CLEANUP_PATH,
+                "{{ time }}",
+                "--cleanup-time",
+                "{{ cleanup_time }}",
+            ],
+            "stop": {
+                "grace_period": 2,
+            },
+        },
+    },
+    "slow cleanup",
+)
+
+IGNORE_TERM_PATH = Path(__file__).parent / "ignore-term.py"
 IGNORE_TERM_JOB = jso_to_job(
     {
         "params": ["time"],
@@ -34,32 +86,49 @@ IGNORE_TERM_JOB = jso_to_job(
 )
 
 
-def test_stop():
+@pytest.mark.parametrize(
+    "job, expected_state, expected_exit_code, expected_signal",
+    [
+        (SLEEP_JOB, "failure", None, "SIGTERM"),
+        (EXIT_ONE_ON_TERM_JOB, "failure", 1, None),
+        (EXIT_ZERO_ON_TERM_JOB, "success", 0, None),
+    ],
+)
+def test_stop(job, expected_state, expected_exit_code, expected_signal):
     svc = ApsisService()
-    dump_job(svc.jobs_dir, SLEEP_JOB)
+    dump_job(svc.jobs_dir, job)
     with svc, svc.agent():
         # Schedule a 3 sec job but tell Apsis to stop it after 1 sec.
         run_id = svc.client.schedule(
-            SLEEP_JOB.job_id,
+            job.job_id,
             {"time": "3"},
             stop_time="+1s",
         )["run_id"]
         res = svc.wait_run(run_id)
 
         # The run was stopped by Apsis, by sending it SIGTERM.
-        assert res["state"] == "failure"
+        assert res["state"] == expected_state
         meta = res["meta"]["program"]
-        assert meta["status"]["signal"] == "SIGTERM"
+        assert meta["status"]["exit_code"] == expected_exit_code
+        assert meta["status"]["signal"] == expected_signal
         assert meta["stop"]["signals"] == ["SIGTERM"]
         assert meta["times"]["elapsed"] < 2
 
 
-def test_stop_api():
+@pytest.mark.parametrize(
+    "job, expected_state, expected_signal",
+    [
+        (SLEEP_JOB, "failure", "SIGTERM"),
+        (EXIT_ZERO_ON_TERM_JOB, "success", None),
+        (EXIT_ONE_ON_TERM_JOB, "failure", None),
+    ],
+)
+def test_stop_api(job, expected_state, expected_signal):
     svc = ApsisService()
-    dump_job(svc.jobs_dir, SLEEP_JOB)
+    dump_job(svc.jobs_dir, job)
     with svc, svc.agent():
         # Schedule a 3 sec job but tell Apsis to stop it after 1 sec.
-        run_id = svc.client.schedule(SLEEP_JOB.job_id, {"time": "3"})["run_id"]
+        run_id = svc.client.schedule(job.job_id, {"time": "3"})["run_id"]
         res = svc.wait_run(run_id, wait_states=("new", "scheduled", "waiting", "starting"))
 
         time.sleep(0.5)
@@ -68,9 +137,9 @@ def test_stop_api():
 
         res = svc.wait_run(run_id)
         # The run was stopped by Apsis, by sending it SIGTERM.
-        assert res["state"] == "failure"
+        assert res["state"] == expected_state
         meta = res["meta"]["program"]
-        assert meta["status"]["signal"] == "SIGTERM"
+        assert meta["status"]["signal"] == expected_signal
         assert meta["stop"]["signals"] == ["SIGTERM"]
         assert meta["times"]["elapsed"] < 2
 
@@ -97,7 +166,7 @@ def test_kill():
     dump_job(svc.jobs_dir, IGNORE_TERM_JOB)
     with svc, svc.agent():
         # Schedule a 5 sec run but tell Apsis to stop it after 1 sec.  The
-        # process ignores SIGTERM so Apsis will send SIGQUIT after the grace
+        # process ignores SIGTERM so Apsis will send SIGKILL after the grace
         # period.
         run_id = svc.client.schedule(IGNORE_TERM_JOB.job_id, {"time": "5"}, stop_time="+1s")[
             "run_id"
@@ -121,11 +190,32 @@ def test_kill():
         assert "done" not in output
 
 
+def test_job_slow_cleanup_within_grace_period():
+    svc = ApsisService()
+    dump_job(svc.jobs_dir, SLOW_CLEANUP_JOB)
+    with svc, svc.agent():
+        run_id = svc.client.schedule(
+            SLOW_CLEANUP_JOB.job_id,
+            {"time": "10", "cleanup_time": "1"},
+            stop_time="+1s",
+        )["run_id"]
+        res = svc.wait_run(run_id)
+
+        assert res["state"] == "success"
+        meta = res["meta"]["program"]
+        assert meta["status"]["exit_code"] == 0
+        assert meta["status"]["signal"] is None
+        assert meta["stop"]["signals"] == ["SIGTERM"]
+        # Should take about 2s (1s wait + 1s cleanup)
+        assert 1.8 < meta["times"]["elapsed"] < 2.5
+
+
 def test_rerun_with_stop():
     near = lambda x, y: abs(x - y) < 0.1
 
-    job_dir = Path(__file__).parent / "jobs"
-    with ApsisService(job_dir=job_dir) as svc, svc.agent():
+    svc = ApsisService()
+    dump_job(svc.jobs_dir, SLEEP_JOB)
+    with svc, svc.agent():
         run_id = svc.client.schedule("sleep", {"time": "10"}, stop_time="+0.5s")["run_id"]
         res = svc.wait_run(run_id)
         assert res["state"] == "failure"

--- a/test/int/procstar/test_stop.py
+++ b/test/int/procstar/test_stop.py
@@ -46,8 +46,8 @@ def test_stop():
         )["run_id"]
         res = svc.wait_run(run_id)
 
-        # The run was successfully stopped by Apsis, by sending it SIGTERM.
-        assert res["state"] == "success"
+        # The run was stopped by Apsis, by sending it SIGTERM.
+        assert res["state"] == "failure"
         meta = res["meta"]["program"]
         assert meta["status"]["signal"] == "SIGTERM"
         assert meta["stop"]["signals"] == ["SIGTERM"]
@@ -67,8 +67,8 @@ def test_stop_api():
         assert res["state"] == "stopping"
 
         res = svc.wait_run(run_id)
-        # The run was successfully stopped by Apsis, by sending it SIGTERM.
-        assert res["state"] == "success"
+        # The run was stopped by Apsis, by sending it SIGTERM.
+        assert res["state"] == "failure"
         meta = res["meta"]["program"]
         assert meta["status"]["signal"] == "SIGTERM"
         assert meta["stop"]["signals"] == ["SIGTERM"]
@@ -128,14 +128,14 @@ def test_rerun_with_stop():
     with ApsisService(job_dir=job_dir) as svc, svc.agent():
         run_id = svc.client.schedule("sleep", {"time": "10"}, stop_time="+0.5s")["run_id"]
         res = svc.wait_run(run_id)
-        assert res["state"] == "success"
+        assert res["state"] == "failure"
         assert near(Time(res["times"]["stop"]), Time(res["times"]["schedule"]) + 0.5)
         meta = res["meta"]["program"]
         assert meta["status"]["signal"] == "SIGTERM"
 
         rerun_id = svc.client.rerun(run_id)["run_id"]
         reres = svc.wait_run(rerun_id)
-        assert reres["state"] == "success"
+        assert reres["state"] == "failure"
         # The rerun should use the old stop time.
         assert reres["times"]["stop"] == res["times"]["stop"]
         # Because of the old stop time, the rerun should have been stopped immediately.


### PR DESCRIPTION
Only zero exit code should be considered as `success`; this also simplifies and makes the logic clearer. In other words: we should not consider as `success` runs that exit with non-zero code only because they received the expected signal while being in the `stopping` state.

As suggested:
> Apsis treating 143 as successful stopping is a bug. 143 indicates termination as a direct result of SIGTERM, in another word, unhandled SIGTERM or crash. In Python this means finally, __exit__ or other cleanup logic is not run, which should not be seen as successful stopping anyway. This aligns with other process supervisors such as systemd.