### PR TITLE
Bugfix: send existing output to new WebSocket connections for running runs

### DIFF
--- a/python/apsis/service/api.py
+++ b/python/apsis/service/api.py
@@ -329,7 +329,7 @@ async def websocket_output_updates(request, ws, run_id, output_id):
         with apsis.output_update_publisher.subscription(run_id) as sub:
             try:
                 output = apsis.outputs.get_output(run_id, output_id)
-                if start is not None and output.compression is not None:
+                if start is not None and output.compression is None:
                     # Send the output data up to now.
                     msg = output_to_http_message(output, interval=(start, None))
                     await ws.send(msg)


### PR DESCRIPTION
When users refresh the live logs page for running runs, previously generated output disappears. Only newly generated output after the page refresh is visible.

We only sends existing output for compressed outputs, **but running run outputs are never compressed** (only finished runs possibly get compressed).
https://github.com/apsis-scheduler/apsis/blob/ef868048a5bcdbd1e3c31e75fc39f4897ab54960/python/apsis/service/api.py#L328
 Therefore, existing output is never sent when establishing new WebSocket connections for running runs.

(For context, this is the commit that introduced the bug 3e83ca3)