### PR TITLE
Add global runtime timeout default and make it configurable

### DIFF
--- a/python/apsis/config.py
+++ b/python/apsis/config.py
@@ -29,6 +29,14 @@ def check(cfg, base_path: Path):
             else:
                 set_cfg(cfg, path, duration)
 
+    def _check_signal(path):
+        signal = get_cfg(cfg, path, None)
+        if signal is not None:
+            try:
+                to_signal(signal)
+            except ValueError as e:
+                log.error(f"invalid signal: {signal}")
+
     job_dir = normalize_path(cfg.get("job_dir", "jobs"), base_path)
     if not job_dir.exists():
         log.error(f"missing job directory: {job_dir}")
@@ -56,13 +64,7 @@ def check(cfg, base_path: Path):
     _check_duration("procstar.agent.run.update_interval")
     _check_duration("procstar.agent.run.output_interval")
     _check_duration("program.timeout.duration")
-
-    timeout_signal = get_cfg(cfg, "program.timeout.signal", None)
-    if timeout_signal is not None:
-        try:
-            to_signal(timeout_signal)
-        except ValueError as exc:
-            log.error(f"invalid signal: {exc}")
+    _check_signal("program.timeout.signal")
 
     # runs_lookback → runs.lookback
     try:

--- a/python/apsis/config.py
+++ b/python/apsis/config.py
@@ -22,20 +22,16 @@ def normalize_path(path, base_path: Path):
 
 def check(cfg, base_path: Path):
     def _check_duration(path):
-        duration = nparse_duration(get_cfg(cfg, path, None))
+        duration_str = get_cfg(cfg, path, None)
+        duration = nparse_duration(duration_str)
         if duration is not None:
             if duration <= 0:
-                log.error(f"negative duration: {path}")
-            else:
-                set_cfg(cfg, path, duration)
+                raise ValueError(f"{path} has negative duration: {duration_str}")
 
     def _check_signal(path):
         signal = get_cfg(cfg, path, None)
         if signal is not None:
-            try:
-                to_signal(signal)
-            except ValueError as e:
-                log.error(f"invalid signal: {signal}")
+            to_signal(signal)
 
     job_dir = normalize_path(cfg.get("job_dir", "jobs"), base_path)
     if not job_dir.exists():

--- a/python/apsis/config.py
+++ b/python/apsis/config.py
@@ -24,7 +24,7 @@ def check(cfg, base_path: Path):
     def _check_duration(path):
         duration = nparse_duration(get_cfg(cfg, path, None))
         if duration is not None and duration <= 0:
-            log.error("negative duration: {path}")
+            log.error(f"negative duration: {path}")
         else:
             set_cfg(cfg, path, duration)
 

--- a/python/apsis/config.py
+++ b/python/apsis/config.py
@@ -23,10 +23,11 @@ def normalize_path(path, base_path: Path):
 def check(cfg, base_path: Path):
     def _check_duration(path):
         duration = nparse_duration(get_cfg(cfg, path, None))
-        if duration is not None and duration <= 0:
-            log.error(f"negative duration: {path}")
-        else:
-            set_cfg(cfg, path, duration)
+        if duration is not None:
+            if duration <= 0:
+                log.error(f"negative duration: {path}")
+            else:
+                set_cfg(cfg, path, duration)
 
     job_dir = normalize_path(cfg.get("job_dir", "jobs"), base_path)
     if not job_dir.exists():
@@ -61,7 +62,7 @@ def check(cfg, base_path: Path):
         try:
             to_signal(timeout_signal)
         except ValueError as exc:
-            log.error(f"invalid program.timeout.signal: {exc}")
+            log.error(f"invalid signal: {exc}")
 
     # runs_lookback → runs.lookback
     try:

--- a/python/apsis/config.py
+++ b/python/apsis/config.py
@@ -54,11 +54,7 @@ def check(cfg, base_path: Path):
 
     cfg["actions"] = to_array(cfg.get("action", []))
 
-    waiting = cfg["waiting"] = cfg.setdefault("waiting", {})
-    max_time = waiting["max_time"] = nparse_duration(waiting.get("max_time", None))
-    if max_time is not None and max_time <= 0:
-        log.error("negative waiting.max_time: {max_time}")
-
+    _check_duration("waiting.max_time")
     _check_duration("procstar.agent.connection.start_timeout")
     _check_duration("procstar.agent.connection.reconnect_timeout")
     _check_duration("procstar.agent.run.update_interval")

--- a/python/apsis/config.py
+++ b/python/apsis/config.py
@@ -6,6 +6,7 @@ from ruamel.yaml import YAML
 from .lib.json import to_array
 from .lib.parse import nparse_duration
 from .lib.py import get_cfg, set_cfg
+from .lib.sys import to_signal
 
 log = logging.getLogger(__name__)
 
@@ -53,6 +54,14 @@ def check(cfg, base_path: Path):
     _check_duration("procstar.agent.connection.reconnect_timeout")
     _check_duration("procstar.agent.run.update_interval")
     _check_duration("procstar.agent.run.output_interval")
+    _check_duration("program.timeout.duration")
+
+    timeout_signal = get_cfg(cfg, "program.timeout.signal", None)
+    if timeout_signal is not None:
+        try:
+            to_signal(timeout_signal)
+        except ValueError as exc:
+            log.error(f"invalid program.timeout.signal: {exc}")
 
     # runs_lookback → runs.lookback
     try:

--- a/python/apsis/program/agent.py
+++ b/python/apsis/program/agent.py
@@ -16,6 +16,7 @@ from .base import (
     program_outputs,
     Timeout,
     RunningProgram,
+    get_global_runtime_timeout,
 )
 from .process import Stop, BoundStop
 from apsis.agent.client import Agent, NoSuchProcessError
@@ -210,6 +211,8 @@ class BoundAgentProgram(Program):
 class RunningAgentProgram(RunningProgram):
     def __init__(self, run_id, program, cfg, run_state=None):
         super().__init__(run_id)
+        if program.timeout is None:
+            program.timeout = get_global_runtime_timeout(cfg)
         self.program = program
         self.cfg = cfg
         self.run_state = run_state

--- a/python/apsis/program/base.py
+++ b/python/apsis/program/base.py
@@ -158,7 +158,7 @@ class Timeout:
 
 def get_global_runtime_timeout(cfg):
     timeout_duration = get_cfg(cfg, "program.timeout.duration", None)
-    if timeout_duration is None or timeout_duration <= 0:
+    if timeout_duration is None:
         return None
     timeout_signal = get_cfg(cfg, "program.timeout.signal", TIMEOUT_SIGNAL)
     return Timeout(duration=timeout_duration, signal=timeout_signal)

--- a/python/apsis/program/base.py
+++ b/python/apsis/program/base.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from signal import Signals
 
 from apsis.lib import memo
 from apsis.lib.api import decompress
@@ -8,8 +9,7 @@ from apsis.lib.py import format_repr, get_cfg
 from apsis.lib.sys import to_signal
 from apsis.runs import template_expand
 
-TIMEOUT_DURATION = 36 * 60 * 60  # 36 hours
-TIMEOUT_SIGNAL = "SIGTERM"
+TIMEOUT_SIGNAL = Signals.SIGTERM.name
 
 # -------------------------------------------------------------------------------
 
@@ -157,7 +157,9 @@ class Timeout:
 
 
 def get_global_runtime_timeout(cfg):
-    timeout_duration = get_cfg(cfg, "program.timeout.duration", TIMEOUT_DURATION)
+    timeout_duration = get_cfg(cfg, "program.timeout.duration", None)
+    if timeout_duration is None or timeout_duration <=0:
+        return None
     timeout_signal = get_cfg(cfg, "program.timeout.signal", TIMEOUT_SIGNAL)
     return Timeout(duration=timeout_duration, signal=timeout_signal)
 

--- a/python/apsis/program/base.py
+++ b/python/apsis/program/base.py
@@ -4,9 +4,12 @@ from apsis.lib import memo
 from apsis.lib.api import decompress
 from apsis.lib.json import TypedJso, check_schema
 from apsis.lib.parse import parse_duration
-from apsis.lib.py import format_repr
+from apsis.lib.py import format_repr, get_cfg
 from apsis.lib.sys import to_signal
 from apsis.runs import template_expand
+
+TIMEOUT_DURATION = 36 * 60 * 60  # 36 hours
+TIMEOUT_SIGNAL = "SIGTERM"
 
 # -------------------------------------------------------------------------------
 
@@ -151,6 +154,12 @@ class Timeout:
         duration = parse_duration(template_expand(self.duration, args))
         signal = to_signal(template_expand(self.signal, args)).name
         return type(self)(duration=duration, signal=signal)
+
+
+def get_global_runtime_timeout(cfg):
+    timeout_duration = get_cfg(cfg, "program.timeout.duration", TIMEOUT_DURATION)
+    timeout_signal = get_cfg(cfg, "program.timeout.signal", TIMEOUT_SIGNAL)
+    return Timeout(duration=timeout_duration, signal=timeout_signal)
 
 
 # -------------------------------------------------------------------------------

--- a/python/apsis/program/base.py
+++ b/python/apsis/program/base.py
@@ -158,7 +158,7 @@ class Timeout:
 
 def get_global_runtime_timeout(cfg):
     timeout_duration = get_cfg(cfg, "program.timeout.duration", None)
-    if timeout_duration is None or timeout_duration <=0:
+    if timeout_duration is None or timeout_duration <= 0:
         return None
     timeout_signal = get_cfg(cfg, "program.timeout.signal", TIMEOUT_SIGNAL)
     return Timeout(duration=timeout_duration, signal=timeout_signal)

--- a/python/apsis/program/procstar/agent.py
+++ b/python/apsis/program/procstar/agent.py
@@ -19,7 +19,13 @@ from apsis.lib.parse import nparse_duration
 from apsis.lib.py import or_none, nstr, get_cfg
 from apsis.procstar import get_agent_server
 from apsis.program import base
-from apsis.program.base import ProgramSuccess, ProgramFailure, ProgramError, Timeout
+from apsis.program.base import (
+    ProgramSuccess,
+    ProgramFailure,
+    ProgramError,
+    Timeout,
+    get_global_runtime_timeout,
+)
 from apsis.program.process import Stop, BoundStop
 from apsis.runs import join_args, template_expand
 
@@ -423,6 +429,8 @@ class RunningProcstarProgram(base.RunningProgram):
           The most recent `Result`, if any.
         """
         super().__init__(run_id)
+        if program.timeout is None:
+            program.timeout = get_global_runtime_timeout(cfg)
         self.program = program
         self.cfg = get_cfg(cfg, "procstar.agent", {})
         self.run_state = run_state

--- a/test/int/procstar/test_timeout.py
+++ b/test/int/procstar/test_timeout.py
@@ -91,7 +91,7 @@ def test_configured_timeout():
         assert res["state"] in ("starting", "running")
 
         res = svc.wait_run(run_id)
-        assert res["state"] == "success"    
+        assert res["state"] == "success"
         assert res["meta"]["program"]["stop"]["signals"] == []
         assert 0.9 < res["meta"]["elapsed"] < 1.1
         assert "timeout" not in res["program"]

--- a/test/int/test_config.py
+++ b/test/int/test_config.py
@@ -67,7 +67,7 @@ def test_invalid_config_values(tmp_path, caplog):
         f"Expected {expected_duration_errors} duration errors, got {duration_error_count}"
     )
     assert signal_error_count == expected_signal_errors, (
-        f"Expected {expected_waiting_errors} signal errors, got {waiting_error_count}"
+        f"Expected {expected_signal_errors} signal errors, got {signal_error_count}"
     )
 
 

--- a/test/int/test_config.py
+++ b/test/int/test_config.py
@@ -67,8 +67,6 @@ def test_invalid_config_values_raise_errors(tmp_path, caplog):
     assert f"not a signal: {invalid_signal}" in str(exc.value)
 
 
-
-
 def test_missing_config_values_not_set_to_none(tmp_path, caplog):
     """
     Test that the config check does not set missing values to None.

--- a/test/int/test_config.py
+++ b/test/int/test_config.py
@@ -57,19 +57,14 @@ def test_invalid_config_values(tmp_path, caplog):
 
     log_messages = [record.message for record in caplog.records if record.levelno == logging.ERROR]
 
-    expected_duration_errors = 6
-    expected_waiting_errors = 1
+    expected_duration_errors = 7
     expected_signal_errors = 1
 
     duration_error_count = sum(1 for msg in log_messages if "negative duration:" in msg)
-    waiting_error_count = sum(1 for msg in log_messages if "negative waiting.max_time:" in msg)
     signal_error_count = sum(1 for msg in log_messages if "invalid signal:" in msg)
 
     assert duration_error_count == expected_duration_errors, (
         f"Expected {expected_duration_errors} duration errors, got {duration_error_count}"
-    )
-    assert waiting_error_count == expected_waiting_errors, (
-        f"Expected {expected_waiting_errors} waiting errors, got {waiting_error_count}"
     )
     assert signal_error_count == expected_signal_errors, (
         f"Expected {expected_waiting_errors} signal errors, got {waiting_error_count}"
@@ -97,5 +92,5 @@ def test_missing_config_values_not_set_to_none(tmp_path, caplog):
     cfg_file.write_text(simple_cfg)
     cfg = apsis.config.load(cfg_file)
     assert "program" not in cfg
-    # assert "waiting" not in cfg
+    assert "waiting" not in cfg
     assert "procstar" not in cfg

--- a/test/int/test_config.py
+++ b/test/int/test_config.py
@@ -1,3 +1,4 @@
+import logging
 import pytest
 
 from ruamel.yaml.constructor import DuplicateKeyError
@@ -21,3 +22,80 @@ def test_duplicate_key_in_config(tmp_path):
 
     with pytest.raises(DuplicateKeyError):
         apsis.config.load(cfg_file)
+
+
+def test_invalid_config_values(tmp_path, caplog):
+    db_file = tmp_path / "test.db"
+    db_file.touch()
+    job_dir = tmp_path / "jobs"
+    job_dir.mkdir()
+    cfg_with_negative_durations = f"""
+    database:
+        path: {db_file}
+        timeout: -30s
+    waiting:
+        max_time: -5m
+    procstar:
+        agent:
+            connection:
+                start_timeout: -2h
+                reconnect_timeout: -15s
+            run:
+                update_interval: -2s
+                output_interval: -1s
+    program:
+        timeout:
+            duration: -3h
+            signal: INVALID_SIGNAL
+    job_dir: {job_dir}
+    """
+
+    cfg_file = tmp_path / "negative_duration_cfg.yaml"
+    cfg_file.write_text(cfg_with_negative_durations)
+
+    apsis.config.load(cfg_file)
+
+    log_messages = [record.message for record in caplog.records if record.levelno == logging.ERROR]
+
+    expected_duration_errors = 6
+    expected_waiting_errors = 1
+    expected_signal_errors = 1
+
+    duration_error_count = sum(1 for msg in log_messages if "negative duration:" in msg)
+    waiting_error_count = sum(1 for msg in log_messages if "negative waiting.max_time:" in msg)
+    signal_error_count = sum(1 for msg in log_messages if "invalid signal:" in msg)
+
+    assert duration_error_count == expected_duration_errors, (
+        f"Expected {expected_duration_errors} duration errors, got {duration_error_count}"
+    )
+    assert waiting_error_count == expected_waiting_errors, (
+        f"Expected {expected_waiting_errors} waiting errors, got {waiting_error_count}"
+    )
+    assert signal_error_count == expected_signal_errors, (
+        f"Expected {expected_waiting_errors} signal errors, got {waiting_error_count}"
+    )
+
+
+def test_missing_config_values_not_set_to_none(tmp_path, caplog):
+    """
+    Test that the config check does not set missing values to None.
+    """
+    db_file = tmp_path / "test.db"
+    db_file.touch()
+
+    job_dir = tmp_path / "jobs"
+    job_dir.mkdir()
+
+    simple_cfg = f"""
+    database:
+        path: {db_file}
+        timeout: -30s
+    job_dir: {job_dir}
+    """
+
+    cfg_file = tmp_path / "simple_cfg.yaml"
+    cfg_file.write_text(simple_cfg)
+    cfg = apsis.config.load(cfg_file)
+    assert "program" not in cfg
+    # assert "waiting" not in cfg
+    assert "procstar" not in cfg


### PR DESCRIPTION
- Fixes: https://github.com/apsis-scheduler/apsis/issues/449

Adding a global configurable runtime timeout value.


--------

I've added to this PR also a fix to the config validation; happy to move this to a different PR if preferred.
In fact, notice that after the first commit the tests were failing with this error:
```
2025-08-01T11:10:00.774 apsis.run_log            E run r8: error: internal: '<' not supported between instances of 'NoneType' and 'float'
Traceback (most recent call last):
  File "/home/runner/work/apsis/apsis/python/apsis/running.py", line 106, in _process_updates
    update = await anext(updates)
  File "/home/runner/work/apsis/apsis/python/apsis/program/agent.py", line 307, in updates
    if self.program.timeout.duration < elapsed:
TypeError: '<' not supported between instances of 'NoneType' and 'float'
```

I have then fixed the issue with this commit https://github.com/apsis-scheduler/apsis/pull/500/commits/f3c35be69a637ebf1b235e5b2c0f8ab1cea63cfd by ensuring we don't set to `None` values that are actually missing in the config due to a bug in `_check_duration`.