### PR TITLE
Bugfix: use parsed duration

### DIFF
--- a/python/apsis/config.py
+++ b/python/apsis/config.py
@@ -27,6 +27,7 @@ def check(cfg, base_path: Path):
         if duration is not None:
             if duration <= 0:
                 raise ValueError(f"{path} has negative duration: {duration_str}")
+            set_cfg(cfg, path, duration)
 
     def _check_signal(path):
         signal = get_cfg(cfg, path, None)


### PR DESCRIPTION
I introduce a small bug in this previous PR https://github.com/apsis-scheduler/apsis/pull/500, which for instance would make a config like 
```
database:
   path: /space/lrighi/apsis_tests/runs.db
   timeout: 120 s
```
to fail with the following error:
```
2025-08-01T16:14:05.265 apsis.ctl                I GC enabled; threshold: (700, 10, 10)
2025-08-01T16:14:05.265 apsis.service.main       I starting Apsis 0.35.0 service
2025-08-01T16:14:05.265 apsis.service.main       I opening state file /space/lrighi/apsis_tests/runs.db
Traceback (most recent call last):
  File "/space/asd/conda7/envs/prod7/bin/apsisctl", line 10, in <module>
    sys.exit(main())
  File "/home/lrighi/apsis/python/apsis/ctl.py", line 251, in main
    status = args.cmd(args)
  File "/home/lrighi/apsis/python/apsis/ctl.py", line 183, in cmd_serve
    restart = apsis.service.main.serve(cfg, host=args.host, port=args.port, debug=args.debug)
  File "/home/lrighi/apsis/python/apsis/service/main.py", line 101, in serve
    apsis = build_apsis(cfg)
  File "/home/lrighi/apsis/python/apsis/service/main.py", line 77, in build_apsis
    db = SqliteDB.open(db_path, timeout=db_cfg.get("timeout"))
  File "/home/lrighi/apsis/python/apsis/sqlite.py", line 724, in open
    engine = cls.__get_engine(path, timeout=timeout)
  File "/home/lrighi/apsis/python/apsis/sqlite.py", line 687, in __get_engine
    engine.execute(f"PRAGMA {pragma} = {value}")
  File "<string>", line 2, in execute
  File "/space/asd/conda7/envs/prod7-20250801-010/lib/python3.10/site-packages/sqlalchemy/util/deprecations.py", line 468, in warned
    return fn(*args, **kwargs)
  File "/space/asd/conda7/envs/prod7-20250801-010/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 3266, in execute
    connection = self.connect(close_with_result=True)
  File "/space/asd/conda7/envs/prod7-20250801-010/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 3325, in connect
    return self._connection_cls(self, close_with_result=close_with_result)
  File "/space/asd/conda7/envs/prod7-20250801-010/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 96, in __init__
    else engine.raw_connection()
  File "/space/asd/conda7/envs/prod7-20250801-010/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 3404, in raw_connection
    return self._wrap_pool_connect(self.pool.connect, _connection)
  File "/space/asd/conda7/envs/prod7-20250801-010/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 3371, in _wrap_pool_connect
    return fn()
  File "/space/asd/conda7/envs/prod7-20250801-010/lib/python3.10/site-packages/sqlalchemy/pool/base.py", line 327, in connect
    return _ConnectionFairy._checkout(self)
  File "/space/asd/conda7/envs/prod7-20250801-010/lib/python3.10/site-packages/sqlalchemy/pool/base.py", line 894, in _checkout
    fairy = _ConnectionRecord.checkout(pool)
  File "/space/asd/conda7/envs/prod7-20250801-010/lib/python3.10/site-packages/sqlalchemy/pool/base.py", line 493, in checkout
    rec = pool._do_get()
  File "/space/asd/conda7/envs/prod7-20250801-010/lib/python3.10/site-packages/sqlalchemy/pool/impl.py", line 445, in _do_get
    rec = self.connection
  File "/space/asd/conda7/envs/prod7-20250801-010/lib/python3.10/site-packages/sqlalchemy/util/langhelpers.py", line 1113, in __get__
    obj.__dict__[self.__name__] = result = self.fget(obj)
  File "/space/asd/conda7/envs/prod7-20250801-010/lib/python3.10/site-packages/sqlalchemy/pool/impl.py", line 405, in connection
    return _ConnectionRecord(self)
  File "/space/asd/conda7/envs/prod7-20250801-010/lib/python3.10/site-packages/sqlalchemy/pool/base.py", line 388, in __init__
    self.__connect()
  File "/space/asd/conda7/envs/prod7-20250801-010/lib/python3.10/site-packages/sqlalchemy/pool/base.py", line 690, in __connect
    with util.safe_reraise():
  File "/space/asd/conda7/envs/prod7-20250801-010/lib/python3.10/site-packages/sqlalchemy/util/langhelpers.py", line 70, in __exit__
    compat.raise_(
  File "/space/asd/conda7/envs/prod7-20250801-010/lib/python3.10/site-packages/sqlalchemy/util/compat.py", line 211, in raise_
    raise exception
  File "/space/asd/conda7/envs/prod7-20250801-010/lib/python3.10/site-packages/sqlalchemy/pool/base.py", line 686, in __connect
    self.dbapi_connection = connection = pool._invoke_creator(self)
  File "/space/asd/conda7/envs/prod7-20250801-010/lib/python3.10/site-packages/sqlalchemy/engine/create.py", line 574, in connect
    return dialect.connect(*cargs, **cparams)
  File "/space/asd/conda7/envs/prod7-20250801-010/lib/python3.10/site-packages/sqlalchemy/engine/default.py", line 598, in connect
    return self.dbapi.connect(*cargs, **cparams)
TypeError: must be real number, not str
```

cc @gusostow 