### PR TITLE
Use fixed cutoff time when retrieving runs to archive

### DIFF
--- a/python/apsis/program/internal/archive.py
+++ b/python/apsis/program/internal/archive.py
@@ -111,12 +111,13 @@ class ArchiveProgram(_InternalProgram):
             },
         }
 
+        archive_cutoff = ora.now() - self.__age
         count = self.__count
         while count > 0:
             chunk = count if self.__chunk_size is None else min(count, self.__chunk_size)
             with Timer() as timer:
                 run_ids = db.get_archive_run_ids(
-                    before=ora.now() - self.__age,
+                    before=archive_cutoff,
                     count=chunk,
                 )
             meta["time"]["get runs"] += timer.elapsed


### PR DESCRIPTION
Since we're running the `get_archive_run_ids` multiple times within the same archive run, it is better to fix the point in time to use to retrieve the runs to be archived. Otherwise, while we're archiving some runs, more runs may become older than the threshold and require archiving too, which is definitely not ideal.

Example
```
2025-10-11T05:51:56.319 apsis.sqlite             I obtained 1500 runs to archive in 0.545 s
2025-10-11T05:52:12.411 apsis.sqlite             I obtained 1500 runs to archive in 0.505 s
2025-10-11T05:52:27.531 apsis.sqlite             I obtained 1500 runs to archive in 0.523 s
2025-10-11T05:55:10.727 apsis.sqlite             I obtained 848 runs to archive in 134.047 s
2025-10-11T05:57:50.817 apsis.sqlite             I obtained 11 runs to archive in 144.467 s
2025-10-11T06:00:17.756 apsis.sqlite             I obtained 12 runs to archive in 135.643 s
2025-10-11T06:02:48.397 apsis.sqlite             I obtained 109 runs to archive in 137.106 s
2025-10-11T06:05:16.064 apsis.sqlite             I obtained 60 runs to archive in 131.812 s
```