### PR TITLE
Stop cycling if there are no more runs to archive

### DIFF
--- a/python/apsis/program/internal/archive.py
+++ b/python/apsis/program/internal/archive.py
@@ -121,6 +121,11 @@ class ArchiveProgram(_InternalProgram):
                     count=chunk,
                 )
             meta["time"]["get runs"] += timer.elapsed
+
+            if not run_ids:
+                # all eligible runs have been archived
+                break
+
             count -= chunk
 
             # Make sure all runs are retired; else skip them.


### PR DESCRIPTION
Currently, the `ArchiveProgram` would continue cycling even if there are no more runs to archive and only stop once `count` is no longer `>0`. That is unnecessary; as soon as we're not obtaining any more runs to archive, we should stop early.


##### Logs related to latest run (`r11287695`)
```
> cat  apsis.log.1 | grep 'obtained '
2025-10-18T09:51:23.566 apsis.sqlite             I obtained 1500 runs to archive in 0.008 s
2025-10-18T09:51:35.187 apsis.sqlite             I obtained 1500 runs to archive in 0.009 s
2025-10-18T09:51:46.708 apsis.sqlite             I obtained 1500 runs to archive in 0.010 s
2025-10-18T09:51:57.869 apsis.sqlite             I obtained 1500 runs to archive in 0.010 s
2025-10-18T09:52:11.334 apsis.sqlite             I obtained 1500 runs to archive in 0.008 s
2025-10-18T09:52:24.863 apsis.sqlite             I obtained 1500 runs to archive in 0.013 s
2025-10-18T09:52:40.024 apsis.sqlite             I obtained 1500 runs to archive in 0.010 s
2025-10-18T09:52:51.897 apsis.sqlite             I obtained 1500 runs to archive in 0.010 s
2025-10-18T09:53:07.224 apsis.sqlite             I obtained 1500 runs to archive in 0.009 s
2025-10-18T09:53:22.585 apsis.sqlite             I obtained 1500 runs to archive in 0.012 s
2025-10-18T09:53:38.772 apsis.sqlite             I obtained 1289 runs to archive in 0.380 s
2025-10-18T09:53:53.953 apsis.sqlite             I obtained 0 runs to archive in 0.342 s
2025-10-18T09:54:04.257 apsis.sqlite             I obtained 0 runs to archive in 0.302 s
(... other 87 lines with 0 runs...)
```
```
> cat  apsis.log.1 | grep 'obtained 0 runs to archive' | wc -l
89
```

```
> cat  apsis.log.1 | grep 'archived '
2025-10-18T09:51:25.171 apsis.sqlite             I archived in 0.840 s
2025-10-18T09:51:36.694 apsis.sqlite             I archived in 0.893 s
2025-10-18T09:51:47.854 apsis.sqlite             I archived in 1.013 s
2025-10-18T09:52:01.321 apsis.sqlite             I archived in 2.836 s
2025-10-18T09:52:14.846 apsis.sqlite             I archived in 3.204 s
2025-10-18T09:52:30.011 apsis.sqlite             I archived in 4.714 s
2025-10-18T09:52:41.883 apsis.sqlite             I archived in 1.198 s
2025-10-18T09:52:57.210 apsis.sqlite             I archived in 4.544 s
2025-10-18T09:53:12.569 apsis.sqlite             I archived in 4.593 s
2025-10-18T09:53:28.387 apsis.sqlite             I archived in 4.712 s
2025-10-18T09:53:43.608 apsis.sqlite             I archived in 3.764 s
```