### PR TITLE
Log fd data length mismatch instead of asserting

### DIFF
--- a/python/apsis/program/procstar/agent.py
+++ b/python/apsis/program/procstar/agent.py
@@ -412,7 +412,10 @@ async def collect_final_fd_data(
                 # Confirm that we've accumulated all the output as
                 # specified in the result.
                 assert fd_data_local.interval.start == 0
-                assert fd_data_local.interval.stop == expected_length
+                if fd_data_local.interval.stop != expected_length:
+                    log.warning(
+                        f"FdData length mismatch: expected {expected_length}, got {fd_data_local.interval.stop}."
+                    )
                 return fd_data_local
 
             case _:


### PR DESCRIPTION
Rather than erroring the run when there is a FdData length mismatch, we just warn log this event.

This may happen for instance when the Procstar process is using multiprocessing. When the main process that Procstar is waiting for terminates, there may be other spawned processes still writing output to stdout.

(For more context, see internal lib issue #19553)

