### PR TITLE
Bump Apsis version in `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -103,7 +103,7 @@ wheels = [
 
 [[package]]
 name = "apsis"
-version = "0.34.2"
+version = "0.36.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
#### Current issue
```
> uv run pytest test/unit test/int -m "not local_ssh"
  × No solution found when resolving dependencies:
  ╰─▶ Because the requested Python version (==3.10.*) does not satisfy Python>=3.13 and procstar==1.1.0 depends on Python>=3.13, we can conclude that procstar==1.1.0 cannot be used.
      And because only the following versions of procstar are available:
          procstar<0.7
          procstar==1.1.0
      and your project depends on procstar>=0.7, we can conclude that your project's requirements are unsatisfiable.

      hint: The `requires-python` value (==3.10.*) includes Python versions that are not supported by your dependencies (e.g., procstar==1.1.0 only supports >=3.13). Consider using a more restrictive `requires-python` value (like >=3.13).
```
#### After fix
```
> gck -
Switched to branch 'lrighi/fix-uv-lock-apsis-version'
Your branch is up to date with 'origin/lrighi/fix-uv-lock-apsis-version'.

> uv run pytest test/unit test/int -m "not local_ssh"
============================================================================================================================== test session starts ==============================================================================================================================
platform linux -- Python 3.10.19, pytest-8.4.1, pluggy-1.6.0
rootdir: /space/lrighi/asd-repos/apsis
configfile: pyproject.toml
plugins: asyncio-1.1.0, anyio-4.9.0
asyncio: mode=strict, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 400 items / 1 deselected / 399 selected                                                                                                                                                                                                                               

test/unit/procstar/test_procstar_agent.py ....                                                                                                                                                                                                                            [  1%]
test/unit/procstar/test_procstar_program.py .....                                                                                                                                                                                                                         [  2%]
test/unit/schedule/test_daily_interval.py ........
```