### PR TITLE
Configure `extra-index-url` for `uv` in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,3 +111,6 @@ filename = "pyproject.toml"
 [[tool.bumpversion.files]]
 filename = "docs/conf.py"
 
+[tool.uv]
+extra-index-url = ["https://apsis-scheduler.github.io/procstar/simple"]
+


### PR DESCRIPTION
### Before the change
```
> uv lock
  × No solution found when resolving dependencies:
  ╰─▶ Because the requested Python version (==3.10.*) does not satisfy Python>=3.13 and procstar==1.1.0 depends on Python>=3.13, we can conclude that
      procstar==1.1.0 cannot be used.
      And because only the following versions of procstar are available:
          procstar<0.7
          procstar==1.1.0
      and your project depends on procstar>=0.7, we can conclude that your project's requirements are unsatisfiable.

      hint: The `requires-python` value (==3.10.*) includes Python versions that are not supported by your dependencies (e.g., procstar==1.1.0 only supports
      >=3.13). Consider using a more restrictive `requires-python` value (like >=3.13).
```
### After the change
```
> uv lock
Resolved 97 packages in 129ms
Updated apsis v0.36.2 -> v0.36.3
```