### PR TITLE
Bugfix: don't show as disabled jobs using stop schedule

### DIFF
--- a/python/apsis/lib/api.py
+++ b/python/apsis/lib/api.py
@@ -107,6 +107,7 @@ def job_to_jso(job):
     def sched_to_jso(s):
         jso = schedule_to_jso(s)
         jso["str"] = str(s) if s.stop_schedule is None else f"{s}, {s.stop_schedule}"
+        jso["enabled"] = s.enabled
         return jso
 
     return {


### PR DESCRIPTION
Issue: jobs using stop schedule as always shown as disabled, although they are not. Notice this is just a UI bug, the job's runs are actually getting scheduled and run as expected.

```
schedule:
  start:
    type: daily
    tz: Europe/London
    daytime: 11:31:00
    enabled: true
  stop:
    type: duration
    duration: 20m
```

### Before the change
```
all days at 11:31:00 Europe/London, stop 1200.0 s after schedule time (disabled)
```

### After the change:
```
all days at 11:31:00 Europe/London, stop 1200.0 s after schedule time
```