### PR TITLE
Add rollback safety net for program types

### DIFF
--- a/python/apsis/lib/json.py
+++ b/python/apsis/lib/json.py
@@ -178,7 +178,7 @@ class TypedJso:
             except KeyError:
                 try:
                     return import_fqname(name)
-                except ImportError as exc:
+                except (ImportError, AttributeError) as exc:
                     raise LookupError(exc)
 
         def get_name(self, type):

--- a/test/unit/test_unavailable_program.py
+++ b/test/unit/test_unavailable_program.py
@@ -1,0 +1,198 @@
+"""Unit tests for UnavailableProgram rollback safety net."""
+
+import pytest
+
+from apsis.exc import SchemaError
+from apsis.program import Program
+from apsis.program.base import (
+    UnavailableProgram,
+    _UnavailableRunningProgram,
+    ProgramError,
+)
+
+
+class TestUnavailableProgram:
+    def test_normal_program_loading(self):
+        """Test that normal program types still load correctly."""
+        # Test a known program type
+        jso = {
+            "type": "no-op",
+            "duration": "10",
+            "success": True,
+        }
+        program = Program.from_jso(jso)
+        assert program.__class__.__name__ == "NoOpProgram"
+        assert program.duration == "10"
+        assert program.success is True
+
+    def test_unknown_program_type_raises_error(self):
+        jso = {
+            "type": "completely.unknown.program.Type",
+            "some": "data",
+        }
+        with pytest.raises(SchemaError) as exc_info:
+            Program.from_jso(jso)
+        assert "unknown program type: completely.unknown.program.Type" in str(exc_info.value)
+
+    def test_rollbackable_unavailable_program_loads(self):
+        # This simulates the ECS program type being unavailable after rollback
+        jso = {
+            "type": "apsis.program.procstar.aws.ecs_agent.BoundProcstarECSProgram",
+            "argv": ["/usr/bin/python", "script.py"],
+            "mem_gb": 4,
+            "vcpu": 2,
+            "disk_gb": 20,
+        }
+
+        # Should return UnavailableProgram, not raise an error
+        program = Program.from_jso(jso)
+        assert isinstance(program, UnavailableProgram)
+        assert program.type_name == "apsis.program.procstar.aws.ecs_agent.BoundProcstarECSProgram"
+
+    def test_unavailable_program_preserves_data(self):
+        original_jso = {
+            "type": "apsis.program.procstar.aws.ecs_agent.BoundProcstarECSProgram",
+            "argv": ["/usr/bin/python", "script.py"],
+            "mem_gb": 4,
+            "vcpu": 2,
+            "disk_gb": 20,
+            "custom_field": "preserved",
+        }
+
+        program = Program.from_jso(original_jso.copy())
+        assert isinstance(program, UnavailableProgram)
+
+        # to_jso should return the original data
+        restored_jso = program.to_jso()
+        assert restored_jso == original_jso
+
+    def test_unavailable_program_bind_raises_error(self):
+        jso = {
+            "type": "apsis.program.procstar.aws.ecs_agent.BoundProcstarECSProgram",
+            "argv": ["/usr/bin/python", "script.py"],
+        }
+
+        program = Program.from_jso(jso)
+        assert isinstance(program, UnavailableProgram)
+
+        # Attempting to bind should raise ProgramError
+        with pytest.raises(ProgramError) as exc_info:
+            program.bind({"arg": "value"})
+        assert "cannot bind unavailable program type" in str(exc_info.value)
+
+    def test_unavailable_program_run_returns_error_runner(self):
+        jso = {
+            "type": "apsis.program.procstar.aws.ecs_agent.BoundProcstarECSProgram",
+            "argv": ["/usr/bin/python", "script.py"],
+        }
+
+        program = Program.from_jso(jso)
+        assert isinstance(program, UnavailableProgram)
+
+        # Running should return _UnavailableRunningProgram
+        runner = program.run("test_run_id", {})
+        assert isinstance(runner, _UnavailableRunningProgram)
+        assert runner.type_name == "apsis.program.procstar.aws.ecs_agent.BoundProcstarECSProgram"
+
+    def test_unavailable_program_connect_returns_error_runner(self):
+        jso = {
+            "type": "apsis.program.procstar.aws.ecs_agent.BoundProcstarECSProgram",
+            "argv": ["/usr/bin/python", "script.py"],
+        }
+
+        program = Program.from_jso(jso)
+        assert isinstance(program, UnavailableProgram)
+
+        # Connecting should return _UnavailableRunningProgram
+        runner = program.connect("test_run_id", {"some": "state"}, {})
+        assert isinstance(runner, _UnavailableRunningProgram)
+        assert runner.type_name == "apsis.program.procstar.aws.ecs_agent.BoundProcstarECSProgram"
+
+    def test_unavailable_program_str_representation(self):
+        jso = {
+            "type": "apsis.program.procstar.aws.ecs_agent.BoundProcstarECSProgram",
+            "argv": ["/usr/bin/python", "script.py"],
+        }
+
+        program = Program.from_jso(jso)
+        assert isinstance(program, UnavailableProgram)
+        assert (
+            str(program)
+            == "UnavailableProgram(apsis.program.procstar.aws.ecs_agent.BoundProcstarECSProgram)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_unavailable_running_program_yields_error(self):
+        runner = _UnavailableRunningProgram("test_run_id", "some.unavailable.Type")
+
+        # The updates generator should yield a ProgramError
+        updates = runner.updates
+        result = await updates.__anext__()
+
+        assert isinstance(result, ProgramError)
+        assert "cannot run unavailable program type: some.unavailable.Type" in str(result)
+
+        # Should only yield one error and then stop
+        with pytest.raises(StopAsyncIteration):
+            await updates.__anext__()
+
+    def test_multiple_rollbackable_types(self):
+        # Temporarily add another type to test
+        original_types = Program.ROLLBACKABLE_PROGRAM_TYPES
+        try:
+            # Add a second rollbackable type
+            Program.ROLLBACKABLE_PROGRAM_TYPES = frozenset(
+                [
+                    "apsis.program.procstar.aws.ecs_agent.BoundProcstarECSProgram",
+                    "another.future.feature.BoundProgram",
+                ]
+            )
+
+            # Both should return UnavailableProgram
+            jso1 = {"type": "apsis.program.procstar.aws.ecs_agent.BoundProcstarECSProgram"}
+            program1 = Program.from_jso(jso1)
+            assert isinstance(program1, UnavailableProgram)
+
+            jso2 = {"type": "another.future.feature.BoundProgram"}
+            program2 = Program.from_jso(jso2)
+            assert isinstance(program2, UnavailableProgram)
+
+            # Unknown type should still raise error
+            jso3 = {"type": "not.in.rollbackable.list"}
+            with pytest.raises(SchemaError):
+                Program.from_jso(jso3)
+
+        finally:
+            # Restore original types
+            Program.ROLLBACKABLE_PROGRAM_TYPES = original_types
+
+    def test_missing_type_key_raises_error(self):
+        jso = {
+            "argv": ["/usr/bin/python", "script.py"],
+            # Missing 'type' key
+        }
+        with pytest.raises(SchemaError) as exc_info:
+            Program.from_jso(jso)
+        assert "missing type" in str(exc_info.value)
+
+    def test_from_jso_preserves_all_fields(self):
+        """Test that all fields are preserved through serialization/deserialization."""
+        jso = {
+            "type": "apsis.program.procstar.aws.ecs_agent.BoundProcstarECSProgram",
+            "argv": ["/usr/bin/python", "script.py", "--verbose"],
+            "stop": {"signal": "SIGTERM", "grace_period": 30},
+            "timeout": {"duration": 3600, "signal": "SIGTERM"},
+            "mem_gb": 8.5,
+            "vcpu": 2.5,
+            "disk_gb": 100,
+            "role": "my-task-role",
+            "task_definition": "my-task-def",
+            "custom_metadata": {"key": "value"},
+        }
+
+        program = Program.from_jso(jso.copy())
+        assert isinstance(program, UnavailableProgram)
+
+        # All fields should be preserved
+        restored = program.to_jso()
+        assert restored == jso


### PR DESCRIPTION
When a feature introduces a new program type (e.g., `apsis.program.procstar.aws.ecs_agent.BoundProcstarECSProgram`), runs using that program are stored in the database. If the feature is later rolled back, Apsis would crash on startup because it cannot de-serialize the unknown program type.

This PR introduces `UnavailableProgram`, a placeholder that allows Apsis to start gracefully when a known program type is unavailable due to rollback.

### Plan:
- merge this PR
- make a new release
- merge https://github.com/apsis-scheduler/apsis/pull/516
- make a new release
- (if needed, safely rollback thanks to this PR)
  - notice this would still require making sure that no jobs use `ProcstarECSProgram`, which can be easily and quickly done