### PR TITLE
Minor bugfix for `BoundSkipDuplicate`

### DIFF
--- a/python/apsis/cond/skip_duplicate.py
+++ b/python/apsis/cond/skip_duplicate.py
@@ -95,7 +95,7 @@ class BoundSkipDuplicate(NonmonotonicRunStoreCondition):
             self,
             check_states=self.__check_states,
             target_state=self.__target_state,
-            job_id=self.__job_id,
+            job_id=self.__run_id,
             inst=self.__inst,
         )
 


### PR DESCRIPTION
Fix a bug in `BoundSkipDuplicate.__repr__` that referenced a nonexistent `self.__job_id` attribute, causing an `AttributeError` whenever `repr()` was called on an instance.
