### PR TITLE
Add timing and cycle checks for job dependencies

### DIFF
--- a/python/apsis/check.py
+++ b/python/apsis/check.py
@@ -1,3 +1,5 @@
+from collections import defaultdict, deque
+
 import ora
 
 from apsis.cond.dependency import Dependency
@@ -85,68 +87,244 @@ def check_job(jobs_dir, job):
             yield from check_associated_run(cond, "condition")
 
 
+def args_key(args):
+    """Stable, hashable key for args."""
+    return tuple(sorted(args.items()))
+
+
+def _format_time(t):
+    return ora.format_time("%Y-%m-%dT%H:%M:%SZ", t, "UTC")
+
+
+def _build_instances(jobs, start, stop):
+    """Build all job instances with their earliest schedule time.
+
+    Returns:
+        dict of (job_id, args_key) -> earliest sched_time
+    """
+    inst_times = {}
+    for job in jobs:
+        for sched_time, _, inst in get_insts_to_schedule(job, start, stop):
+            key = (job.job_id, args_key(inst.args))
+            if key not in inst_times or sched_time < inst_times[key]:
+                inst_times[key] = sched_time
+    return inst_times
+
+
+def _build_dep_graph(jobs_dir, jobs_obj, inst_times):
+    """Build forward and reverse dependency edges for known instances.
+
+    Returns:
+        (graph, deps_of) where:
+        - graph: dep_node -> [dependent_nodes]  (forward edges)
+        - deps_of: node -> [its dependency nodes]  (reverse edges)
+    """
+    graph = defaultdict(list)
+    deps_of = defaultdict(list)
+
+    for job_id, args_k in inst_times:
+        job = jobs_dir.get_job(job_id)
+        inst = Instance(job_id, dict(args_k))
+        run = Run(inst)
+
+        for cond in job.conds:
+            if not isinstance(cond, Dependency):
+                continue
+            bound = cond.bind(run, jobs_obj)
+            if not bound:
+                continue
+            dep_node = (bound.job_id, args_key(bound.args))
+            if dep_node in inst_times:
+                graph[dep_node].append((job_id, args_k))
+                deps_of[(job_id, args_k)].append(dep_node)
+
+    return graph, deps_of
+
+
+def _propagate_expected_starts(inst_times, graph):
+    """Propagate expected start times via topological traversal (Kahn’s algorithm).
+
+    The expected start of a node is the max of its own schedule time and
+    those of its transitive dependencies.  Does not account for run durations.
+
+    Returns:
+        (exp_start, cycle_nodes) where cycle_nodes is empty if no cycles.
+    """
+    indegree = {node: 0 for node in inst_times}
+    for dependents in graph.values():
+        for node in dependents:
+            indegree[node] += 1
+
+    exp_start = dict(inst_times)
+    queue = deque(node for node in inst_times if indegree[node] == 0)
+
+    while queue:
+        node = queue.popleft()
+        for nxt in graph[node]:
+            if exp_start[node] > exp_start[nxt]:
+                exp_start[nxt] = exp_start[node]
+            indegree[nxt] -= 1
+            if indegree[nxt] == 0:
+                queue.append(nxt)
+
+    cycle_nodes = {node for node in inst_times if indegree[node] > 0}
+    return exp_start, cycle_nodes
+
+
+def _find_cycle(cycle_nodes, deps_of):
+    """Extract one representative cycle path from the remaining nodes.
+
+    Walks deps_of from an arbitrary node until revisiting one, then returns
+    the cycle as "A → B → C → A".  Not guaranteed to find the shortest cycle.
+    """
+    start = next(iter(cycle_nodes))
+    visited = {}
+    node = start
+    path = []
+
+    while node not in visited:
+        visited[node] = len(path)
+        path.append(node)
+        node = next(
+            (d for d in deps_of.get(node, []) if d in cycle_nodes),
+            None,
+        )
+        if node is None:
+            break
+
+    if node is not None and node in visited:
+        cycle = path[visited[node] :] + [node]
+        return " → ".join(job_id for job_id, _ in cycle)
+    return ", ".join(job_id for job_id, _ in list(cycle_nodes)[:5])
+
+
+def _build_delay_tree(node, deps_of, exp_start, inst_times, indent=0, seen=None):
+    """Build indented lines explaining why `node` is delayed.
+
+    Only includes dependencies whose expected start actually pushes this
+    node later than its own schedule time.
+    """
+    if seen is None:
+        seen = set()
+    if node in seen:
+        return []
+    seen.add(node)
+
+    blocking = [d for d in deps_of.get(node, []) if exp_start[d] > inst_times[node]]
+    pad = "  " * indent
+
+    if not blocking:
+        time_str = _format_time(inst_times[node])
+        return [f"{pad}- It’s scheduled to start at {time_str}."]
+
+    lines = []
+    for dep in blocking:
+        dep_inst = Instance(dep[0], dict(dep[1]))
+        time_str = _format_time(exp_start[dep])
+        lines.append(
+            f"{pad}- dependency: {dep_inst} not expected to"
+            f" start until {time_str}."
+            f" This is because:"
+        )
+        lines.extend(_build_delay_tree(dep, deps_of, exp_start, inst_times, indent + 1, seen))
+    return lines
+
+
 def check_job_dependencies_scheduled(
     jobs_dir,
-    job,
+    jobs,
     *,
     sched_times=None,
     dep_times=None,
+    max_wait_time=None,
 ):
     """
-    Attempts to check that dependencies are scheduled.
+    Validate that job dependencies are scheduled and respect timing constraints.
 
-    For each run of `job` scheduled within `sched_times`, looks for
-    dependencies.  For each dependency, checks that there is a matching run of
-    that job scheduled in `dep_times`.
+    For each scheduled run of the given jobs within `sched_times`, this checks:
+    - A matching scheduled run exists for each dependency within `dep_times`
+    - The dependency is not scheduled too late relative to the job run
 
-    :param sched_times:
-      (start, stop) time interval for scheduled runs of `job` to consider.  If
-      none, uses (now, now + 1 day).
-    :param dep_times:
-      (start, stop) time interval in which to look for scheduled runs of
-      dependencies.  If none, uses (now - 1 day, now + 1 day).
-    :return:
-      Generator of errors indicating apparently unscheduled dependencies.
+    If `max_wait_time` is provided, emits an error if dependency delay exceeds it.
+
+    Yields:
+        (job, message)
     """
-    deps = [c for c in job.conds if isinstance(c, Dependency)]
-    if len(deps) == 0:
-        return
 
-    jobs = Jobs(jobs_dir, MockJobDb())
-    time = ora.now()
+    now = ora.now()
+    sched_start, sched_stop = sched_times or (now, now + 86400)
+    dep_start, dep_stop = dep_times or (now - 86400, now + 86400)
 
-    sched_start, sched_stop = sched_times if sched_times is not None else (time, time + 86400)
-    dep_start, dep_stop = dep_times if dep_times is not None else (time - 86400, time + 86400)
-    dep_ivl = f"[{dep_start}, {dep_stop})"
+    jobs_obj = Jobs(jobs_dir, MockJobDb())
 
-    # Cache for dependent job schedules: job_id -> set of frozenset(argdict.items())
-    dep_insts = {}
+    # Build the dependency graph and propagate expected start times.
+    inst_times = _build_instances(jobs, dep_start, dep_stop)
+    graph, deps_of = _build_dep_graph(jobs_dir, jobs_obj, inst_times)
+    exp_start, cycle_nodes = _propagate_expected_starts(inst_times, graph)
 
-    def get_dep_insts(job):
-        try:
-            return dep_insts[job.job_id]
-        except KeyError:
-            insts = list(get_insts_to_schedule(job, dep_start, dep_stop))
-            dep_insts[job.job_id] = {frozenset(inst.args.items()) for _, _, inst in insts}
-            return dep_insts[job.job_id]
+    # Report cycles.
+    if cycle_nodes:
+        cycle_str = _find_cycle(cycle_nodes, deps_of)
+        for job_id in sorted({jid for jid, _ in cycle_nodes}):
+            yield (
+                jobs_dir.get_job(job_id),
+                f"dependency cycle detected: {cycle_str}",
+            )
 
-    # Construct all instances that will be scheduled soon.
-    insts = get_insts_to_schedule(job, sched_start, sched_stop)
+    # Validate each job’s instances.
+    for job in jobs:
+        dep_conds = [c for c in job.conds if isinstance(c, Dependency)]
+        if not dep_conds:
+            continue
 
-    for _, _, inst in insts:
-        run = Run(inst)
-        # Check each dependency.
-        for dep in deps:
-            # Bind the dependency to get the precise args that match.
-            dep = dep.bind(run, jobs)
-            if dep is None:
-                # Dependency disabled by `enabled` condition.
+        timing_reported = False
+
+        for sched_time, _, inst in get_insts_to_schedule(job, sched_start, sched_stop):
+            run = Run(inst)
+            inst_node = (job.job_id, args_key(inst.args))
+
+            # Check for unscheduled dependencies.
+            for dep in dep_conds:
+                bound = dep.bind(run, jobs_obj)
+                if not bound:
+                    continue
+                dep_node = (bound.job_id, args_key(bound.args))
+                if dep_node not in inst_times:
+                    dep_inst = Instance(bound.job_id, bound.args)
+                    yield (
+                        job,
+                        f"scheduled run {inst}: dependency {dep_inst} not scheduled",
+                    )
+
+            # Timing check: only report once per job (first violating instance).
+            # Skip cycle nodes — their exp_start is invalid.
+            if (
+                max_wait_time is None
+                or timing_reported
+                or inst_node not in exp_start
+                or inst_node in cycle_nodes
+            ):
                 continue
 
-            # Look at scheduled runs of the dependency job.  Check if any
-            # matches the dependency args.
-            dep_job = jobs_dir.get_job(dep.job_id)
-            if frozenset(dep.args.items()) not in get_dep_insts(dep_job):
-                # No matches.
-                dep_inst = Instance(dep.job_id, dep.args)
-                yield (f"scheduled run {inst}: dependency {dep_inst} not scheduled in {dep_ivl}")
+            wait = exp_start[inst_node] - sched_time
+            if wait <= max_wait_time:
+                continue
+
+            exp_str = _format_time(exp_start[inst_node])
+            sched_str = _format_time(sched_time)
+            wait_h = wait / 3600
+            max_h = max_wait_time / 3600
+            header = (
+                f"{inst} not expected to start until {exp_str},"
+                f" {wait_h:.0f}h after scheduled time {sched_str}"
+                f" (max_wait={max_h:.0f}h)."
+                f" This is because:"
+            )
+            tree_lines = _build_delay_tree(
+                inst_node,
+                deps_of,
+                exp_start,
+                inst_times,
+            )
+            yield (job, header + "\n" + "\n".join(tree_lines))
+            timing_reported = True

--- a/python/apsis/ctl.py
+++ b/python/apsis/ctl.py
@@ -81,10 +81,11 @@ def main():
                 status = 1
 
         if jobs_dir is not None and args.check_dependencies_scheduled:
-            for job in jobs_dir.get_jobs():
-                for err in apsis.check.check_job_dependencies_scheduled(jobs_dir, job):
-                    con.print(f"{job.job_id}: {err}", style="error")
-                    status = 1
+            for job, msg in apsis.check.check_job_dependencies_scheduled(
+                jobs_dir, jobs_dir.get_jobs()
+            ):
+                con.print(f"{job.job_id}: {msg}", style="error", soft_wrap=True)
+                status = 1
 
         return status
 

--- a/test/int/basic/test_check_jobs.py
+++ b/test/int/basic/test_check_jobs.py
@@ -1,13 +1,15 @@
+import shutil
+from pathlib import Path
+
+import ora
+import pytest
 import yaml
 
-from pathlib import Path
-import pytest
-import shutil
-
+import apsis.jobs
 from apsis.check import check_job_dependencies_scheduled
 from apsis.exc import JobsDirErrors, SchemaError
-import apsis.jobs
-from apsis.lib import itr
+
+DAY_IN_SEC = 86400
 
 # -------------------------------------------------------------------------------
 
@@ -185,13 +187,11 @@ async def test_check_job_dependencies_scheduled(tmp_path):
 
     async def check():
         jobs_dir = await apsis.jobs.load_jobs_dir(jobs_path)
-        return list(
-            itr.chain(*(check_job_dependencies_scheduled(jobs_dir, j) for j in jobs_dir.get_jobs()))
-        )
+        return [msg for _, msg in check_job_dependencies_scheduled(jobs_dir, jobs_dir.get_jobs())]
 
     # The dependent isn't scheduled, so no error.
-    errs = await check()
-    assert len(errs) == 0
+    results = await check()
+    assert len(results) == 0
 
     # Schedule the dependent.  Now there are errors, because the dependency is
     # not scheduled.
@@ -212,9 +212,9 @@ async def test_check_job_dependencies_scheduled(tmp_path):
         },
     ]
     dump_yaml_file(dependent, jobs_path / "dependent.yaml")
-    errs = await check()
-    assert any("label=foo" in e for e in errs)
-    assert any("label=bar" in e for e in errs)
+    results = await check()
+    assert any("label=foo" in msg for msg in results)
+    assert any("label=bar" in msg for msg in results)
 
     # Schedule the dependency of one of the scheduled dependents.  There are
     # still errors, because of the dependency of the other scheduled dependent.
@@ -228,9 +228,9 @@ async def test_check_job_dependencies_scheduled(tmp_path):
         },
     ]
     dump_yaml_file(dependency, jobs_path / "dependency.yaml")
-    errs = await check()
-    assert any("label=foo" in e for e in errs)
-    assert not any("label=bar" in e for e in errs)
+    results = await check()
+    assert any("label=foo" in msg for msg in results)
+    assert not any("label=bar" in msg for msg in results)
 
     # Schedule the other dependency.  No more errors.
     dependency["schedule"].append(
@@ -243,5 +243,227 @@ async def test_check_job_dependencies_scheduled(tmp_path):
         },
     )
     dump_yaml_file(dependency, jobs_path / "dependency.yaml")
-    errs = await check()
-    assert len(errs) == 0
+    results = await check()
+    assert len(results) == 0
+
+
+@pytest.mark.asyncio
+async def test_check_dependency_timing(tmp_path):
+    """
+    Tests that check_job_dependencies_scheduled with max_wait_time detects
+    dependencies scheduled too late relative to the dependent job.
+    """
+    jobs_path = tmp_path
+    now = ora.now()
+
+    dependent = {
+        "params": ["date"],
+        "schedule": {
+            "type": "daily",
+            "tz": "UTC",
+            "calendar": "Mon-Sun",
+            "daytime": "06:00:00",
+        },
+        "condition": {
+            "type": "dependency",
+            "job_id": "dependency",
+        },
+        "program": {"type": "no-op"},
+    }
+
+    # Dependency scheduled 2h after dependent (08:00 vs 06:00).
+    dependency = {
+        "params": ["date"],
+        "schedule": {
+            "type": "daily",
+            "tz": "UTC",
+            "calendar": "Mon-Sun",
+            "daytime": "08:00:00",
+        },
+        "program": {"type": "no-op"},
+    }
+
+    dump_yaml_file(dependent, jobs_path / "dependent.yaml")
+    dump_yaml_file(dependency, jobs_path / "dependency.yaml")
+
+    sched_times = (now, now + DAY_IN_SEC * 30)
+    dep_times = (now - DAY_IN_SEC * 8, now + DAY_IN_SEC * 38)
+
+    async def check(max_wait_time=None):
+        jobs_dir = await apsis.jobs.load_jobs_dir(jobs_path)
+        return [
+            msg
+            for _, msg in check_job_dependencies_scheduled(
+                jobs_dir,
+                jobs_dir.get_jobs(),
+                sched_times=sched_times,
+                dep_times=dep_times,
+                max_wait_time=max_wait_time,
+            )
+        ]
+
+    # No timing parameters: no timing check, no results.
+    results = await check()
+    assert len(results) == 0
+
+    # max_wait_time=3h: 2h gap is within limit, no errors.
+    results = await check(max_wait_time=10800)
+    assert len(results) == 0
+
+    # max_wait_time=1h: 2h gap exceeds limit, should error.
+    results = await check(max_wait_time=3600)
+    assert len(results) == 1
+    assert "not expected to start until" in results[0]
+
+    # Dependency scheduled BEFORE dependent (04:00 vs 06:00) — never an issue.
+    dependency["schedule"]["daytime"] = "04:00:00"
+    dump_yaml_file(dependency, jobs_path / "dependency.yaml")
+    results = await check(max_wait_time=3600)
+    assert len(results) == 0
+
+    # Dependency scheduled 20h after dependent (02:00 next day vs 06:00).
+    # With max_wait_time=23h (82800s), this should pass.
+    dependency["schedule"]["daytime"] = "02:00:00"
+    dependency["schedule"]["date_shift"] = 1
+    dump_yaml_file(dependency, jobs_path / "dependency.yaml")
+    results = await check(max_wait_time=82800)
+    assert len(results) == 0
+
+    # But with max_wait_time=18h, the 20h gap should fail.
+    results = await check(max_wait_time=64800)
+    assert len(results) == 1
+    assert "not expected to start until" in results[0]
+
+
+@pytest.mark.asyncio
+async def test_check_dependency_timing_transitive(tmp_path):
+    """
+    Tests that transitive dependency timing is checked.
+
+    A (01:00) -> B (11:00) -> C (21:00), max_wait_time=12h.
+    Each direct gap is 10h (< 12h), but A transitively has to wait for C
+    (20h > 12h) because B won't succeed until C completes.
+    """
+    jobs_path = tmp_path
+    now = ora.now()
+
+    dump_yaml_file(
+        {
+            "params": ["date"],
+            "schedule": {
+                "type": "daily",
+                "tz": "UTC",
+                "calendar": "Mon-Sun",
+                "daytime": "01:00:00",
+            },
+            "condition": {"type": "dependency", "job_id": "b"},
+            "program": {"type": "no-op"},
+        },
+        jobs_path / "a.yaml",
+    )
+    dump_yaml_file(
+        {
+            "params": ["date"],
+            "schedule": {
+                "type": "daily",
+                "tz": "UTC",
+                "calendar": "Mon-Sun",
+                "daytime": "11:00:00",
+            },
+            "condition": {"type": "dependency", "job_id": "c"},
+            "program": {"type": "no-op"},
+        },
+        jobs_path / "b.yaml",
+    )
+    dump_yaml_file(
+        {
+            "params": ["date"],
+            "schedule": {
+                "type": "daily",
+                "tz": "UTC",
+                "calendar": "Mon-Sun",
+                "daytime": "21:00:00",
+            },
+            "program": {"type": "no-op"},
+        },
+        jobs_path / "c.yaml",
+    )
+
+    sched_times = (now, now + DAY_IN_SEC * 30)
+    dep_times = (now - DAY_IN_SEC * 8, now + DAY_IN_SEC * 38)
+
+    async def check(max_wait_time):
+        jobs_dir = await apsis.jobs.load_jobs_dir(jobs_path)
+        return list(
+            check_job_dependencies_scheduled(
+                jobs_dir,
+                jobs_dir.get_jobs(),
+                sched_times=sched_times,
+                dep_times=dep_times,
+                max_wait_time=max_wait_time,
+            )
+        )
+
+    # With 12h max: direct gaps (10h) are fine, but A must transitively wait
+    # for C (20h).  Job A should be flagged.
+    results = await check(max_wait_time=43200)
+    a_errors = [msg for job, msg in results if job.job_id == "a"]
+    assert len(a_errors) > 0, "Expected transitive timing error for job A"
+    # The tree should mention c as the transitive bottleneck.
+    assert any("dependency: c(" in msg for msg in a_errors)
+
+    # B->C direct gap (10h) is fine, so B itself should not be flagged.
+    b_errors = [msg for job, msg in results if job.job_id == "b"]
+    assert len(b_errors) == 0, "B's direct dep (10h) is within 12h max"
+
+    # With 22h max: 20h transitive gap is fine.
+    results = await check(max_wait_time=79200)
+    a_errors = [msg for job, msg in results if job.job_id == "a"]
+    assert len(a_errors) == 0
+
+
+@pytest.mark.asyncio
+async def test_check_dependency_cycle(tmp_path):
+    """
+    Tests that a cycle in the dependency graph yields errors.
+
+    A -> B -> C -> A forms a cycle.
+    """
+    jobs_path = tmp_path
+    now = ora.now()
+
+    for name, dep in [("a", "b"), ("b", "c"), ("c", "a")]:
+        dump_yaml_file(
+            {
+                "params": ["date"],
+                "schedule": {
+                    "type": "daily",
+                    "tz": "UTC",
+                    "calendar": "Mon-Sun",
+                    "daytime": "06:00:00",
+                },
+                "condition": {"type": "dependency", "job_id": dep},
+                "program": {"type": "no-op"},
+            },
+            jobs_path / f"{name}.yaml",
+        )
+
+    jobs_dir = await apsis.jobs.load_jobs_dir(jobs_path)
+
+    results = list(
+        check_job_dependencies_scheduled(
+            jobs_dir,
+            jobs_dir.get_jobs(),
+            sched_times=(now, now + DAY_IN_SEC * 30),
+            dep_times=(now - DAY_IN_SEC * 8, now + DAY_IN_SEC * 38),
+            max_wait_time=82800,
+        )
+    )
+
+    # Each job in the cycle should get an error.
+    cycle_errors = [(job.job_id, msg) for job, msg in results]
+    assert len(cycle_errors) >= 3
+    # The message should show the cycle path, not a list of instances.
+    assert all("dependency cycle detected:" in msg for _, msg in cycle_errors)
+    # The cycle should mention the job names with arrows.
+    assert any("→" in msg for _, msg in cycle_errors)


### PR DESCRIPTION
Extends `check_job_dependencies_scheduled` to catch two new classes of problems in job configurations:

**Timing checks:** When `max_wait_time` is set, the checker builds a dependency graph across all scheduled jobs and computes expected start times, accounting for transitive dependencies. If a job can't start until well after its scheduled time because a dependency (or a dependency's dependency) is scheduled too late, an error is reported with a tree-style explanation of the full blocking chain.

**Cycle detection:** The dependency graph is checked for cycles. If a cycle exists (e.g. A depends on B, B depends on C, C depends on A), errors are reported for all jobs involved, with the cycle path shown.

Both checks integrate into the existing `check-jobs` CLI flow and produce structured `(job, level, message)` tuples. 

(Also sneaked in `soft_wrap=True` to preserve tree indentation in the terminal)


### Example output

Timing violation:
```
A: A(date=2026-04-27) not expected to start until 2026-04-27T22:59:59Z, 24h after scheduled time 2026-04-26T23:00:01Z (max_wait=23h). This is because:
- dependency: B(date=2026-04-27) not expected to start until 2026-04-27T22:59:59Z. This is because:
  - dependency: C(date=2026-04-27) not expected to start until 2026-04-27T22:59:59Z. This is because:
    - It's scheduled to start at 2026-04-27T22:59:59Z.
```

Cycle detection:
```
A: dependency cycle detected: A → B → C → A
```