### PR TITLE
Parse job yaml in a background threadpool

### DIFF
--- a/python/apsis/jobs.py
+++ b/python/apsis/jobs.py
@@ -244,8 +244,6 @@ async def load_jobs_dir(path, yaml_loader=None):
     jobs = {}
     errors = []
 
-    loop = asyncio.get_running_loop()
-
     async def load_job(path, job_id):
         log.debug(f"loading: {path}")
         try:
@@ -259,7 +257,7 @@ async def load_jobs_dir(path, yaml_loader=None):
                     job_jso = YAML().load(content)
                 return Job.from_jso(job_jso, job_id)
 
-            job = await loop.run_in_executor(None, _parse)
+            job = await asyncio.to_thread(_parse)
             return job_id, job, None
         except DuplicateKeyError as exc:
             err_msg = exc.problem if exc.problem else str(exc)

--- a/python/apsis/jobs.py
+++ b/python/apsis/jobs.py
@@ -244,16 +244,22 @@ async def load_jobs_dir(path, yaml_loader=None):
     jobs = {}
     errors = []
 
+    loop = asyncio.get_running_loop()
+
     async def load_job(path, job_id):
         log.debug(f"loading: {path}")
         try:
             async with aiofiles.open(path, mode="r") as file:
                 content = await file.read()
-            if yaml_loader is not None:
-                job_jso = yaml.load(content, Loader=yaml_loader)
-            else:
-                job_jso = YAML().load(content)
-            job = Job.from_jso(job_jso, job_id)
+
+            def _parse():
+                if yaml_loader is not None:
+                    job_jso = yaml.load(content, Loader=yaml_loader)
+                else:
+                    job_jso = YAML().load(content)
+                return Job.from_jso(job_jso, job_id)
+
+            job = await loop.run_in_executor(None, _parse)
             return job_id, job, None
         except DuplicateKeyError as exc:
             err_msg = exc.problem if exc.problem else str(exc)
@@ -279,6 +285,8 @@ async def load_jobs_dir(path, yaml_loader=None):
         log.info(f"checking: {job.job_id}")
         for err in check_job(jobs_dir, job):
             errors.append(JobError(job.job_id, str(err)))
+        # be nice to the event loop
+        await asyncio.sleep(0)
 
     if len(errors) > 0:
         raise JobsDirErrors(f"errors loading jobs in {jobs_path}", errors)


### PR DESCRIPTION
It turns out the event loop parses the thousands of yaml files back to back, which is taking 15s in our environment. If we have the bad luck of this running after a GC gen 2 collection then we start to have problems...

This does make loading jobs about 20% slower but that's fine as long as the event loop is happy.

The `asyncio.sleep(0)` is just to save from a subsequent few second hang on top of that.