### PR TITLE
Bugfixes for async load jobs performance

### DIFF
--- a/python/apsis/jobs.py
+++ b/python/apsis/jobs.py
@@ -13,6 +13,7 @@ from .actions import Action
 from .actions.schedule import successor_from_jso
 from .cond import Condition
 from .exc import JobError, JobsDirErrors, SchemaError
+from .lib import itr
 from .lib.json import to_array, to_narray, check_schema
 from .lib.py import tupleize, format_ctor
 from .program import Program, NoOpProgram
@@ -270,12 +271,13 @@ async def load_jobs_dir(path, yaml_loader=None):
             return job_id, None, exc
 
     load_coros = [load_job(path, job_id) for path, job_id in list_yaml_files(jobs_path)]
-    results = await asyncio.gather(*load_coros)
-    for job_id, job, exc in results:
-        if job is not None:
-            jobs[job_id] = job
-        if exc is not None:
-            errors.append(exc)
+    for chunk in itr.chunks(load_coros, 100):
+        results = await asyncio.gather(*chunk)
+        for job_id, job, exc in results:
+            if job is not None:
+                jobs[job_id] = job
+            if exc is not None:
+                errors.append(exc)
 
     jobs_dir = JobsDir(jobs_path, jobs)
 

--- a/python/apsis/service/main.py
+++ b/python/apsis/service/main.py
@@ -50,6 +50,10 @@ class Router(sanic.router.Router):
 app = sanic.Sanic("apsis", router=Router(), log_config=SANIC_LOG_CONFIG)
 app.config.LOGO = None
 
+# sanic sends a 503 if requests take longer to service than this
+# motivation to increase is to prevent timeouts on /reload_jobs
+app.config.RESPONSE_TIMEOUT = 180
+
 # more forgiving for when slow browsers can't keep up with websocket messages
 app.config.WEBSOCKET_PING_TIMEOUT = 300
 app.config.WEBSOCKET_PING_INTERVAL = 100


### PR DESCRIPTION
Fixes two issues with parsing yaml in a threadpool PR https://github.com/apsis-scheduler/apsis/pull/531.

1. The slowdown was more than I expected under realistic load. This pushed it over Sanic's default 60s timeout, which sent 503 to clients. I increased the default to 180s which seems like a reasonable default.


2. Using gather to create a task for every single job ended up choking the event loop as well because of sheer scheduling load, which didn't show up in my toy testing for some reason. Doing this in batches of 100 fixes the problem in my more realistic testing under load. Loop pauses are down to the GC baseline.