### PR TITLE
Remove bind at startup

### DIFF
--- a/python/apsis/apsis.py
+++ b/python/apsis/apsis.py
@@ -101,21 +101,6 @@ class Apsis:
             min_timestamp = now() - lookback
         self.run_store = RunStore(db, min_timestamp=min_timestamp)
 
-        # Previously we didn't serialize conds or actions.  Bind them if
-        # missing on loaded runs.
-        # FIXME: Remove this after a while.
-        for run in self.run_store.query()[1]:
-            if run.actions is None or run.conds is None or run.program is None:
-                try:
-                    job = self.jobs.get_job(run.inst.job_id)
-                except LookupError:
-                    log.info(f"failed to bind {run}: job not found")
-                    continue
-                try:
-                    bind(run, job, self.jobs)
-                except Exception as exc:
-                    log.info(f"failed to bind {run}: {exc}")
-
         self.outputs = OutputStore(db.output_db)
 
         # Continue scheduling from the last time we handled scheduled jobs.


### PR DESCRIPTION
This is a preliminary startup performance optimization for when the run store starts to query sqlite on-demand. It's not slow currently, but it will be slow after that change (20-30s).

I've queried our prod DB and I see that we have a 11 rows with null values here. Some of them are recent -- they're all jobs that failed to bind at runtime like adhoc runs, and some things that aren't caught by the jobs check.

I tested that nothing falls over without this bind at startup even if a few runs have nulls for actions/conds/program.