### PR TITLE
Add more filtering to RunDB

### DIFF
--- a/python/apsis/cond/skip_duplicate.py
+++ b/python/apsis/cond/skip_duplicate.py
@@ -141,7 +141,7 @@ class BoundSkipDuplicate(NonmonotonicRunStoreCondition):
     def from_jso(cls, jso):
         with check_schema(jso) as pop:
             return cls(
-                check_states=pop("check_states", to_states),
+                check_states=list(pop("check_states", to_states)),
                 target_state=pop("target_state", to_state),
                 inst=pop("instance", Instance.from_jso),
                 run_id=pop("run_id", str),

--- a/python/apsis/sqlite.py
+++ b/python/apsis/sqlite.py
@@ -495,8 +495,11 @@ class RunDB:
         with Timer() as timer:
             runs = list(self.__query_runs(self.__engine, expr))
 
+        def fmt_params(**kwargs):
+            return " ".join(f"{k}={v}" for k, v in kwargs.items() if v is not None)
+
         log.debug(
-            f"query job_id={job_id} since={since} state={state} "
+            f"query {fmt_params(run_ids=run_ids, job_id=job_id, since=since, state=state, args=args, with_args=with_args, min_timestamp=min_timestamp)} "
             f"→ {len(runs)} runs in {timer.elapsed:.3f}s"
         )
         return runs

--- a/python/apsis/sqlite.py
+++ b/python/apsis/sqlite.py
@@ -482,12 +482,16 @@ class RunDB:
         if args is not None:
             args = {str(k): str(v) for k, v in args.items()}
             for k, v in args.items():
-                where.append(sa.literal_column(f"json_extract(args, '$.{k}')") == v)
+                # escape key for JSON path to handle dots, quotes, etc
+                path = '$."' + k.replace('"', '\\"') + '"'
+                where.append(sa.func.json_extract(TBL_RUNS.c.args, path) == v)
             where.append(sa.literal_column("(SELECT count(*) FROM json_each(args))") == len(args))
         elif with_args is not None:
             with_args = {str(k): str(v) for k, v in with_args.items()}
             for k, v in with_args.items():
-                where.append(sa.literal_column(f"json_extract(args, '$.{k}')") == v)
+                # escape key for JSON path to handle dots, quotes, etc
+                path = '$."' + k.replace('"', '\\"') + '"'
+                where.append(sa.func.json_extract(TBL_RUNS.c.args, path) == v)
         if min_timestamp is not None:
             where.append(TBL_RUNS.c.timestamp >= dump_time(min_timestamp))
 

--- a/python/apsis/sqlite.py
+++ b/python/apsis/sqlite.py
@@ -7,12 +7,13 @@ import logging
 import ora
 from pathlib import Path
 import sqlalchemy as sa
+from typing import Iterable, Optional
 import ujson
 
 from .actions.base import Action
 from .cond.base import Condition
 from .jobs import jso_to_job, job_to_jso
-from .lib import itr
+from .lib import itr, py
 from .lib.timing import Timer
 from .runs import Instance, Run
 from .states import State
@@ -444,23 +445,66 @@ class RunDB:
             (run,) = self.__query_runs(conn, TBL_RUNS.c.run_id == run_id)
         return run
 
-    def query(self, *, job_id=None, since=None, min_timestamp=None):
+    def query(
+        self,
+        *,
+        run_ids=None,
+        job_id=None,
+        since=None,
+        state: Iterable[State] | Optional[State] = None,
+        args=None,
+        with_args=None,
+        min_timestamp=None,
+    ):
         """
+        :param run_ids:
+          If not none, limits to runs with the specified run IDs.
+        :param state:
+          If not none, limits to runs in the specified state(s).
+        :param args:
+          If not none, limits to runs with exactly the specified args dict.
+        :param with_args:
+          If not none, limits to runs that contain at least these args.
+          Ignored if args is also specified.
         :param min_timestamp:
           If not none, limits to runs with timestamp not less than this.
         """
         where = []
+        if run_ids is not None:
+            where.append(TBL_RUNS.c.run_id.in_(list(run_ids)))
         if job_id is not None:
             where.append(TBL_RUNS.c.job_id == job_id)
         if since is not None:
             where.append(TBL_RUNS.c.rowid >= int(since))
+        if state is not None:
+            states = py.tupleize(state)
+            where.append(TBL_RUNS.c.state.in_([s.name for s in states]))
+        if args is not None:
+            args = {str(k): str(v) for k, v in args.items()}
+            for k, v in args.items():
+                where.append(
+                    sa.literal_column(f"json_extract(args, '$.{k}')") == v
+                )
+            where.append(
+                sa.literal_column("(SELECT count(*) FROM json_each(args))")
+                == len(args)
+            )
+        elif with_args is not None:
+            with_args = {str(k): str(v) for k, v in with_args.items()}
+            for k, v in with_args.items():
+                where.append(
+                    sa.literal_column(f"json_extract(args, '$.{k}')") == v
+                )
         if min_timestamp is not None:
             where.append(TBL_RUNS.c.timestamp >= dump_time(min_timestamp))
 
-        runs = list(self.__query_runs(self.__engine, sa.and_(*where)))
+        expr = sa.and_(*where)
+        with Timer() as timer:
+            runs = list(self.__query_runs(self.__engine, expr))
 
         log.debug(
-            f"query job_id={job_id} since={since} min_timestamp={min_timestamp} → {len(runs)} runs"
+            f"query job_id={job_id} since={since} state={state} "
+            f"→ {len(runs)} runs in {timer.elapsed:.3f}s"
         )
         return runs
 

--- a/python/apsis/sqlite.py
+++ b/python/apsis/sqlite.py
@@ -482,19 +482,12 @@ class RunDB:
         if args is not None:
             args = {str(k): str(v) for k, v in args.items()}
             for k, v in args.items():
-                where.append(
-                    sa.literal_column(f"json_extract(args, '$.{k}')") == v
-                )
-            where.append(
-                sa.literal_column("(SELECT count(*) FROM json_each(args))")
-                == len(args)
-            )
+                where.append(sa.literal_column(f"json_extract(args, '$.{k}')") == v)
+            where.append(sa.literal_column("(SELECT count(*) FROM json_each(args))") == len(args))
         elif with_args is not None:
             with_args = {str(k): str(v) for k, v in with_args.items()}
             for k, v in with_args.items():
-                where.append(
-                    sa.literal_column(f"json_extract(args, '$.{k}')") == v
-                )
+                where.append(sa.literal_column(f"json_extract(args, '$.{k}')") == v)
         if min_timestamp is not None:
             where.append(TBL_RUNS.c.timestamp >= dump_time(min_timestamp))
 

--- a/python/apsis/sqlite.py
+++ b/python/apsis/sqlite.py
@@ -451,7 +451,7 @@ class RunDB:
         run_ids=None,
         job_id=None,
         since=None,
-        state: Iterable[State] | Optional[State] = None,
+        state: Iterable[State] | State | None = None,
         args=None,
         with_args=None,
         min_timestamp=None,

--- a/test/unit/test_run_db_query.py
+++ b/test/unit/test_run_db_query.py
@@ -1,0 +1,155 @@
+"""
+Tests for RunDB.query() predicate pushdown to SQLite.
+"""
+import ora
+
+from apsis.runs import Instance, Run
+from apsis.sqlite import SqliteDB
+from apsis.states import State
+
+
+def _make_run(run_db, job_id, args, state=State.success):
+    """Create a run, insert it via upsert, and return it."""
+    inst = Instance(job_id, args)
+    run = Run(inst)
+    _make_run._counter += 1
+    run.run_id = f"r{_make_run._counter}"
+    run.timestamp = ora.now()
+    run.state = state
+    run.times = {state.name: run.timestamp}
+    run.meta = {}
+    run_db.upsert(run)
+    return run
+
+
+_make_run._counter = 0
+
+
+def _setup(tmp_path):
+    path = tmp_path / "apsis.db"
+    SqliteDB.create(path=path)
+    db = SqliteDB.open(path)
+    _make_run._counter = 0
+    return db.run_db
+
+
+# -------------------------------------------------------------------------------
+
+
+def test_query_all(tmp_path):
+    run_db = _setup(tmp_path)
+    r1 = _make_run(run_db, "job/a", {"date": "2026-01-01"})
+    r2 = _make_run(run_db, "job/b", {"date": "2026-01-02"})
+
+    runs = run_db.query()
+    assert {r.run_id for r in runs} == {r1.run_id, r2.run_id}
+
+
+def test_query_by_job_id(tmp_path):
+    run_db = _setup(tmp_path)
+    r1 = _make_run(run_db, "job/a", {"date": "2026-01-01"})
+    _make_run(run_db, "job/b", {"date": "2026-01-02"})
+
+    runs = run_db.query(job_id="job/a")
+    assert [r.run_id for r in runs] == [r1.run_id]
+
+
+def test_query_by_state(tmp_path):
+    run_db = _setup(tmp_path)
+    r1 = _make_run(run_db, "job/a", {}, state=State.success)
+    _make_run(run_db, "job/a", {}, state=State.failure)
+    r3 = _make_run(run_db, "job/a", {}, state=State.error)
+
+    runs = run_db.query(state=(State.success, State.error))
+    assert {r.run_id for r in runs} == {r1.run_id, r3.run_id}
+
+
+def test_query_by_run_ids(tmp_path):
+    run_db = _setup(tmp_path)
+    r1 = _make_run(run_db, "job/a", {})
+    _make_run(run_db, "job/b", {})
+    r3 = _make_run(run_db, "job/c", {})
+
+    runs = run_db.query(run_ids=[r1.run_id, r3.run_id])
+    assert {r.run_id for r in runs} == {r1.run_id, r3.run_id}
+
+
+def test_query_by_args_exact(tmp_path):
+    run_db = _setup(tmp_path)
+    r1 = _make_run(run_db, "job/a", {"date": "2026-01-01", "strat": "us"})
+    _make_run(run_db, "job/a", {"date": "2026-01-01", "strat": "eu"})
+    _make_run(run_db, "job/a", {"date": "2026-01-01"})
+
+    runs = run_db.query(args={"date": "2026-01-01", "strat": "us"})
+    assert [r.run_id for r in runs] == [r1.run_id]
+
+
+def test_query_by_args_no_superset_match(tmp_path):
+    """args= requires exact match, not superset."""
+    run_db = _setup(tmp_path)
+    _make_run(run_db, "job/a", {"date": "2026-01-01", "strat": "us"})
+
+    runs = run_db.query(args={"date": "2026-01-01"})
+    assert runs == []
+
+
+def test_query_by_with_args(tmp_path):
+    run_db = _setup(tmp_path)
+    r1 = _make_run(run_db, "job/a", {"date": "2026-01-01", "strat": "us"})
+    r2 = _make_run(run_db, "job/a", {"date": "2026-01-01", "strat": "eu"})
+    _make_run(run_db, "job/a", {"date": "2026-01-02", "strat": "us"})
+
+    runs = run_db.query(with_args={"date": "2026-01-01"})
+    assert {r.run_id for r in runs} == {r1.run_id, r2.run_id}
+
+
+def test_query_with_args_superset_matches(tmp_path):
+    """with_args= matches runs with extra keys beyond those specified."""
+    run_db = _setup(tmp_path)
+    r1 = _make_run(run_db, "job/a", {"date": "2026-01-01", "strat": "us", "extra": "val"})
+
+    runs = run_db.query(with_args={"date": "2026-01-01", "strat": "us"})
+    assert [r.run_id for r in runs] == [r1.run_id]
+
+
+def test_query_args_overrides_with_args(tmp_path):
+    """When both args and with_args are provided, args takes precedence."""
+    run_db = _setup(tmp_path)
+    r1 = _make_run(run_db, "job/a", {"date": "2026-01-01"})
+    _make_run(run_db, "job/a", {"date": "2026-01-01", "strat": "us"})
+
+    runs = run_db.query(args={"date": "2026-01-01"}, with_args={"date": "2026-01-01"})
+    assert [r.run_id for r in runs] == [r1.run_id]
+
+
+def test_query_combined_predicates(tmp_path):
+    run_db = _setup(tmp_path)
+    _make_run(run_db, "job/a", {"date": "2026-01-01"}, state=State.success)
+    r2 = _make_run(run_db, "job/a", {"date": "2026-01-01"}, state=State.failure)
+    _make_run(run_db, "job/b", {"date": "2026-01-01"}, state=State.failure)
+
+    runs = run_db.query(
+        job_id="job/a",
+        state=(State.failure,),
+        args={"date": "2026-01-01"},
+    )
+    assert [r.run_id for r in runs] == [r2.run_id]
+
+
+def test_query_empty_args(tmp_path):
+    """Runs with empty args match args={}."""
+    run_db = _setup(tmp_path)
+    r1 = _make_run(run_db, "job/a", {})
+    _make_run(run_db, "job/a", {"date": "2026-01-01"})
+
+    runs = run_db.query(args={})
+    assert [r.run_id for r in runs] == [r1.run_id]
+
+
+def test_query_json_order_independence(tmp_path):
+    """Args match regardless of JSON serialization order."""
+    run_db = _setup(tmp_path)
+    r1 = _make_run(run_db, "job/a", {"z_key": "val1", "a_key": "val2"})
+
+    runs = run_db.query(args={"a_key": "val2", "z_key": "val1"})
+    assert [r.run_id for r in runs] == [r1.run_id]

--- a/test/unit/test_run_db_query.py
+++ b/test/unit/test_run_db_query.py
@@ -154,3 +154,53 @@ def test_query_json_order_independence(tmp_path):
 
     runs = run_db.query(args={"a_key": "val2", "z_key": "val1"})
     assert [r.run_id for r in runs] == [r1.run_id]
+
+
+def test_query_args_with_dots_in_key(tmp_path):
+    """Args with dots in keys should match correctly."""
+    run_db = _setup(tmp_path)
+    r1 = _make_run(run_db, "job/a", {"a.b": "x"})
+    _make_run(run_db, "job/a", {"a": {"b": "x"}})  # nested structure, should not match
+
+    runs = run_db.query(args={"a.b": "x"})
+    assert [r.run_id for r in runs] == [r1.run_id]
+
+
+def test_query_with_args_dots_in_key(tmp_path):
+    """with_args with dots in keys should match correctly."""
+    run_db = _setup(tmp_path)
+    r1 = _make_run(run_db, "job/a", {"a.b": "x", "other": "val"})
+
+    runs = run_db.query(with_args={"a.b": "x"})
+    assert [r.run_id for r in runs] == [r1.run_id]
+
+
+def test_query_args_with_quotes_in_key(tmp_path):
+    """Args with double quotes in keys should match correctly."""
+    run_db = _setup(tmp_path)
+    r1 = _make_run(run_db, "job/a", {'wei"rd': "y"})
+
+    runs = run_db.query(args={'wei"rd': "y"})
+    assert [r.run_id for r in runs] == [r1.run_id]
+
+
+def test_query_args_with_special_chars_in_value(tmp_path):
+    """Args with special chars in values should match correctly."""
+    run_db = _setup(tmp_path)
+    r1 = _make_run(run_db, "job/a", {"name": "o'brien"})
+    r2 = _make_run(run_db, "job/a", {"path": "a/b/c"})
+
+    runs = run_db.query(args={"name": "o'brien"})
+    assert [r.run_id for r in runs] == [r1.run_id]
+
+    runs = run_db.query(args={"path": "a/b/c"})
+    assert [r.run_id for r in runs] == [r2.run_id]
+
+
+def test_query_args_with_spaces_in_key(tmp_path):
+    """Args with spaces in keys should match correctly."""
+    run_db = _setup(tmp_path)
+    r1 = _make_run(run_db, "job/a", {"key with spaces": "value"})
+
+    runs = run_db.query(args={"key with spaces": "value"})
+    assert [r.run_id for r in runs] == [r1.run_id]

--- a/test/unit/test_run_db_query.py
+++ b/test/unit/test_run_db_query.py
@@ -1,6 +1,7 @@
 """
 Tests for RunDB.query() predicate pushdown to SQLite.
 """
+
 import ora
 
 from apsis.runs import Instance, Run

--- a/uv.lock
+++ b/uv.lock
@@ -103,10 +103,11 @@ wheels = [
 
 [[package]]
 name = "apsis"
-version = "1.0.0"
+version = "2.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
+    { name = "boto3" },
     { name = "brotli" },
     { name = "httpx" },
     { name = "jinja2" },
@@ -121,6 +122,13 @@ dependencies = [
     { name = "sqlalchemy" },
     { name = "ujson" },
     { name = "websockets" },
+]
+
+[package.optional-dependencies]
+doc = [
+    { name = "readthedocs-sphinx-ext" },
+    { name = "sphinx" },
+    { name = "sphinx-rtd-theme" },
 ]
 
 [package.dev-dependencies]
@@ -141,21 +149,26 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp" },
+    { name = "boto3" },
     { name = "brotli" },
     { name = "httpx" },
     { name = "jinja2" },
     { name = "ora", specifier = "<0.9.0" },
     { name = "procstar", specifier = ">=0.7" },
     { name = "pyyaml" },
+    { name = "readthedocs-sphinx-ext", marker = "extra == 'doc'" },
     { name = "requests" },
     { name = "rich" },
     { name = "ruamel-yaml" },
     { name = "sanic", specifier = "==21.6" },
     { name = "sanic-routing", specifier = "==0.7.0" },
+    { name = "sphinx", marker = "extra == 'doc'" },
+    { name = "sphinx-rtd-theme", marker = "extra == 'doc'" },
     { name = "sqlalchemy", specifier = "<2" },
     { name = "ujson" },
     { name = "websockets", specifier = ">=14" },
 ]
+provides-extras = ["doc"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -206,6 +219,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.43.33"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/9d/794d03504b8c72bf978a1ef93bc9e7d0867951bf5fbbe50881cd50fb26d5/boto3-1.43.33.tar.gz", hash = "sha256:da6e400b2d11eb041fbbb2743ef3ffe6540889676ffdff0e628628e9b4f04cde", size = 113152, upload-time = "2026-06-18T19:35:00.57Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/42/bb88180fe1e46f77fe9507083a256dad243747e29aa0f2fbf6ff421b4132/boto3-1.43.33-py3-none-any.whl", hash = "sha256:97b563127f7678ad20249f9bf99877b7a3a78f6fcdcf222c6e25d27d4406ce0d", size = 140534, upload-time = "2026-06-18T19:34:58.062Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.33"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/d5/8ec6df4e82bec2be4ac417f542736dc6cfe89152693337152421b336eb71/botocore-1.43.33.tar.gz", hash = "sha256:74b3d5626ebeb2677fac1ca12ac975faf328e54349ceb4dcda17f50674d5b9b4", size = 15586539, upload-time = "2026-06-18T19:34:48.44Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/f5/55fc2d15a81ae39115ebcf8db876f54e78f834446b468e178c9de8e7977e/botocore-1.43.33-py3-none-any.whl", hash = "sha256:4292bb2cc645e5cb404515c54b5b164563f2b4218c52aeee3f1ce851724e177a", size = 15272140, upload-time = "2026-06-18T19:34:44.056Z" },
 ]
 
 [[package]]
@@ -530,6 +571,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -876,6 +926,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1025,6 +1087,18 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.19.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/94/dcdaeb1713cab9c84def276cfac7388b17c7d9855bbcfe88d77e4dbafd44/s3transfer-0.19.0.tar.gz", hash = "sha256:ce436931687addc4c1712d52d40b32f53e88315723f107ffa20ba82b05a0f685", size = 165171, upload-time = "2026-06-16T19:44:51.599Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/5f/4c174edad94f82de888ac00a5ddd8d07b35609b6c94f0bdf4d74af57703e/s3transfer-0.19.0-py3-none-any.whl", hash = "sha256:777cc2415536f1debadb5c2ef7779275d0fc0fe0e042411cdd6caebeb2685262", size = 90101, upload-time = "2026-06-16T19:44:50.439Z" },
+]
+
+[[package]]
 name = "sanic"
 version = "21.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1049,6 +1123,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0e/1e/4177a94e7da63d57eed28cce99336951af1d170727f2892d310e80ae1a80/sanic-routing-0.7.0.tar.gz", hash = "sha256:bd6e30b9252d3500e0224e9bb64ba52561638991cefa1f7281c3ba75795c7df9", size = 22541, upload-time = "2021-06-27T20:01:05.778Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cd/02/09a2b116a88aa1e7c6e7ef50316032b061a4f8da4ed7d145aa66af88213c/sanic_routing-0.7.0-py3-none-any.whl", hash = "sha256:278771ba4182ff60e75dbf8b674158409283f133eb19948a3df7dff02f642719", size = 23221, upload-time = "2021-06-27T20:01:04.219Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Performance preparations for loading RunStore data from sqlite instead of keeping in memory. This allows us to push filters down to sqlite instead of needing to deserialize all runs before filtering in memory.

This PR itself isn't risky because it's a new feature that doesn't change any runtime behavior. RunStore filtering will still be in-memory for now.