### PR TITLE
Bugfix: serialize runs in a background thread

### DIFF
--- a/python/apsis/service/api.py
+++ b/python/apsis/service/api.py
@@ -489,7 +489,16 @@ async def runs(request):
         with_args=args,
     )
 
-    return response_json(runs_to_jso(request.app, when, runs, summary=summary))
+    # offload JSON serialization to thread pool to avoid blocking event loop
+    # runs is a generator, so materialize it first in the async context
+    runs_list = list(runs)
+
+    def serialize_runs():
+        return runs_to_jso(request.app, when, runs_list, summary=summary)
+
+    result = await asyncio.to_thread(serialize_runs)
+
+    return response_json(result)
 
 
 async def _send_chunked(msgs, ws, prefix):


### PR DESCRIPTION
This is endpoint is only called by the `apsis runs` CLI command. It blocks the event loop for 60s in our environment if called without filters.
 
Note that I'm going to have to do something about a potential full run store query in the same method, once that is slower from serving the run store from sqlite instead of memory https://github.com/apsis-scheduler/apsis/pull/538.
 
https://github.com/apsis-scheduler/apsis/blob/64be4c43fc7404364a7576ec4b0dd8feb7dd1e79/python/apsis/service/api.py#L484-L490