### PR TITLE
Bugfix: avoid locking DB due to summary generator

### DIFF
--- a/python/apsis/sqlite.py
+++ b/python/apsis/sqlite.py
@@ -512,6 +512,10 @@ class RunDB:
 
 # -------------------------------------------------------------------------------
 
+# Chosen empirically to balance performance and GC pressure. Smaller batches can be deallocated before they cause a
+# gen 0 collection
+_SUMMARY_BATCH_SIZE = 256
+
 
 class RunSummaryDB:
     TABLE = sa.Table(
@@ -552,14 +556,39 @@ class RunSummaryDB:
         self.__connection.connection.commit()
 
     def query(self, min_timestamp: ora.Time | None = None) -> Iterator[str]:
-        with self.__engine.begin() as conn:
-            stmt = sa.select(self.TABLE.c.payload)
-            if min_timestamp is not None:
-                stmt = stmt.where(self.TABLE.c.timestamp >= dump_time(min_timestamp))
-            stmt = stmt.order_by(self.TABLE.c.timestamp.desc())
-            cursor = conn.execute(stmt)
-            for (payload,) in cursor:
-                yield payload
+        # Use independent paged queries to prevent holding a read cursor across the yield, which seems to cause
+        # write-lock errors when paired with litestream. Note that his problem isn't fully understood and hasn't been
+        # satisfactorily reproduced in isolation.
+
+        # This query logic is passably-incorrect because it does not
+        # fetch from a static snapshot; when summary timestamps are updated mid-iteration they will be missing from the
+        # query. This is ok because the websocket summary endpoint replays all new updates during the query using the
+        # summary publisher.
+        max_ts = None
+        while True:
+            with self.__engine.begin() as conn:
+                stmt = sa.select(self.TABLE.c.timestamp, self.TABLE.c.payload)
+                if min_timestamp is not None:
+                    stmt = stmt.where(self.TABLE.c.timestamp >= dump_time(min_timestamp))
+                if max_ts is not None:
+                    stmt = stmt.where(self.TABLE.c.timestamp < max_ts)
+                stmt = stmt.order_by(self.TABLE.c.timestamp.desc())
+                stmt = stmt.limit(_SUMMARY_BATCH_SIZE)
+                rows = conn.execute(stmt).fetchall()
+
+            if not rows:
+                break
+
+            max_ts = rows[-1][0]
+            count = len(rows)
+            payloads = [r[1] for r in rows]
+            del rows
+
+            yield from payloads
+
+            del payloads
+            if count < _SUMMARY_BATCH_SIZE:
+                break
 
 
 # -------------------------------------------------------------------------------

--- a/test/unit/test_run_summaries.py
+++ b/test/unit/test_run_summaries.py
@@ -1,3 +1,6 @@
+import sqlite3
+import threading
+
 import ora
 import ujson
 
@@ -6,11 +9,14 @@ from apsis.sqlite import SqliteDB
 from apsis.states import State
 
 
-def make_run_store(tmp_path, min_timestamp=ora.now() - 86400):
+def make_db(tmp_path):
     path = tmp_path / "apsis.db"
     SqliteDB.create(path)
-    db = SqliteDB.open(path)
-    return RunStore(db, min_timestamp=min_timestamp)
+    return SqliteDB.open(path)
+
+
+def make_run_store(tmp_path, min_timestamp=ora.now() - 86400):
+    return RunStore(make_db(tmp_path), min_timestamp=min_timestamp)
 
 
 def test_min_timestamp_none(tmp_path):
@@ -53,6 +59,53 @@ def test_timestamp_updated(tmp_path):
 
     # assert timestamp is updated
     assert ts1 > ts0
+
+
+def test_no_db_lock_truncate(tmp_path):
+    """ClockDB write must not fail when an external process does TRUNCATE checkpoints
+    while a summaries() generator is open.
+    """
+    db_path = tmp_path / "apsis.db"
+    SqliteDB.create(db_path)
+    db = SqliteDB.open(db_path, timeout=5)
+    run_store = RunStore(db, min_timestamp=ora.now() - 86400)
+
+    for i in range(100):
+        run = Run(Instance("test/job", {"date": f"2026-01-{i:02d}"}), expected=False)
+        run_store.add(run)
+        run._transition(ora.now(), State.scheduled, times={"schedule": ora.now()})
+        run_store.update(run, ora.now())
+
+    stop = threading.Event()
+    errors = []
+
+    def truncate_loop():
+        conn = sqlite3.connect(str(db_path), timeout=1)
+        conn.execute("PRAGMA journal_mode=WAL")
+        while not stop.is_set():
+            try:
+                conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            except sqlite3.OperationalError:
+                pass
+            stop.wait(0.01)
+        conn.close()
+
+    t = threading.Thread(target=truncate_loop, daemon=True)
+    t.start()
+
+    try:
+        for _ in range(25):
+            gen = run_store.summaries()
+            next(gen)
+            try:
+                db.clock_db.set_time(ora.now())
+            except sqlite3.OperationalError as exc:
+                errors.append(exc)
+    finally:
+        stop.set()
+        t.join()
+
+    assert not errors, f"ClockDB.set_time() failed {len(errors)} times: {errors[0]}"
 
 
 def test_summaries_includes_expected_runs(tmp_path):


### PR DESCRIPTION
Follow up to https://github.com/apsis-scheduler/apsis/pull/536

After about 10min of landing the above we hit a `sqlite3.OperationalError: database is locked` exception for writing to the ClockDB. This seems to get hit when that happens concurrently with starting a new tab which fetches the run summary history.

I have not been able to reproduce in normal testing, but it stands to reason that this has something to do with the prod litestream backups. Though the logs don't indicate that it was doing any aggressive truncate checkpointing which blocks writers.

However, running this in a loop was able to reproduce exactly the same symptoms at least. 
```
while true; do date; sqlite3 apsis.db 'PRAGMA busy_timeout=50000; PRAGMA wal_checkpoint(TRUNCATE);'; sleep 1; done
```
It's not obvious what was causing the same behavior in prod though, but the symptoms are so close I'm treating this as a reproducer.

Note that querying summaries in batches basically doubles the query time, but the GC contribution is still negligible, which is what matters. It's also still faster than serializing the status-quo of serializing all the JSON.

CC @LudovicoRighi 