### PR TITLE
Bump ver in uv.lock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,8 +113,8 @@ filename = "pyproject.toml"
 
 [[tool.bumpversion.files]]
 filename = "uv.lock"
-search = 'name = "apsis"\nversion = "{current_version}"'
-replace = 'name = "apsis"\nversion = "{new_version}"'
+search = "name = \"apsis\"\nversion = \"{current_version}\""
+replace = "name = \"apsis\"\nversion = \"{new_version}\""
 
 [[tool.bumpversion.files]]
 filename = "docs/conf.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,11 @@ tag_name = "v{new_version}"
 filename = "pyproject.toml"
 
 [[tool.bumpversion.files]]
+filename = "uv.lock"
+search = 'name = "apsis"\nversion = "{current_version}"'
+replace = 'name = "apsis"\nversion = "{new_version}"'
+
+[[tool.bumpversion.files]]
 filename = "docs/conf.py"
 
 [tool.uv]

--- a/uv.lock
+++ b/uv.lock
@@ -103,7 +103,7 @@ wheels = [
 
 [[package]]
 name = "apsis"
-version = "2.2.2"
+version = "2.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Stops the lock file from being updated every time there is an apsis release.