### PR TITLE
Fail `ArchiveProgram` when `count` is exhausted with runs remaining

### DIFF
--- a/docs/programs.rst
+++ b/docs/programs.rst
@@ -437,6 +437,10 @@ starting scheduled runs.  If the `chunk_size` parameter is omitted, all runs are
 archived in one chunk.  If the `chunk_sleep` parameter is omitted, Apsis does
 not pause between chunks.
 
+If `count` is exhausted while eligible runs remain, the run **fails**.  This
+signals that `count` is too small, or the program runs too infrequently, and the
+database will grow; raise `count` or archive more often.
+
 The archive file is also an SQLite3 database file, and contains the subset of
 columns from the main database file that contains run data.  The archive file
 cannot be used directly by Apsis, but may be useful for historical analysis and

--- a/python/apsis/program/internal/archive.py
+++ b/python/apsis/program/internal/archive.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import ora
 
-from ..base import _InternalProgram, ProgramRunning, ProgramSuccess
+from ..base import _InternalProgram, ProgramFailure, ProgramRunning, ProgramSuccess
 from apsis.lib.json import check_schema, nkey
 from apsis.lib.parse import parse_duration
 from apsis.lib.timing import Timer
@@ -36,7 +36,8 @@ class ArchiveProgram(_InternalProgram):
           Path to the archive file, a SQLite database in a format similar to the
           Apsis database file.
         :param count:
-          Maximum number of runs to archive per run of this program.
+          Maximum number of runs to archive per run of this program.  If it is
+          exhausted while eligible runs remain, the run fails.
         :param chunk_size:
           Number of runs to archive in one chunk.  Each chunk is blocking.
         :param chunk_sleep:
@@ -145,6 +146,22 @@ class ArchiveProgram(_InternalProgram):
             if count > 0 and self.__chunk_sleep is not None:
                 # Yield to the event loop.
                 await asyncio.sleep(self.__chunk_sleep)
+
+        if count <= 0:
+            # `count` was exhausted; if eligible runs remain, it's too small and
+            # the database will accumulate a backlog.  Fail loudly rather than
+            # succeed quietly, reporting how many runs are still eligible so the
+            # operator knows how much to raise `count`.  The metadata still
+            # reports the archived runs.
+            remaining = db.count_archive_run_ids(before=archive_cutoff)
+            if remaining > 0:
+                msg = (
+                    f"archive count {self.__count} exhausted with {remaining} "
+                    f"eligible runs remaining; increase count or archive more "
+                    f"frequently"
+                )
+                log.error(msg)
+                raise ProgramFailure(msg, meta=meta)
 
         return ProgramSuccess(meta=meta)
 

--- a/python/apsis/sqlite.py
+++ b/python/apsis/sqlite.py
@@ -1009,6 +1009,26 @@ class SqliteDB:
         log.info(f"obtained {len(run_ids)} runs to archive in {timer.elapsed:.3f} s")
         return run_ids
 
+    def count_archive_run_ids(self, *, before):
+        """
+        Counts runs eligible for archive.
+
+        :param before:
+          Time before which to archive runs.
+        :return:
+          The number of eligible runs.
+        """
+        # Only finished runs are eligible for archiving.
+        FINISHED_STATES = [s.name for s in State if s.finished]
+
+        with self.__engine.begin() as tx:
+            return tx.execute(
+                sa.select(sa.func.count())
+                .select_from(TBL_RUNS)
+                .where(TBL_RUNS.c.timestamp < dump_time(before))
+                .where(TBL_RUNS.c.state.in_(FINISHED_STATES))
+            ).scalar()
+
     def archive(self, path, run_ids):
         """
         Archives data for `run_ids` to sqlite archive file `path`.

--- a/test/int/test_archive.py
+++ b/test/int/test_archive.py
@@ -169,6 +169,77 @@ def test_archive_chunks(tmp_path):
             assert all(r[0] in run_ids and r[1] == "success" for r in rows)
 
 
+def test_archive_truncated(tmp_path):
+    """
+    When `count` is exhausted while eligible runs remain, the run fails, and the
+    archived runs are still reported.
+    """
+    path = tmp_path / "archive.db"
+    job_dir = tmp_path / "jobs"
+    job_dir.mkdir()
+
+    with closing(
+        ApsisService(
+            cfg={"schedule": {"horizon": 1}},
+            job_dir=job_dir,
+        )
+    ) as inst:
+        inst.create_db()
+        inst.write_cfg()
+        inst.start_serve()
+        inst.wait_for_serve()
+
+        client = inst.client
+
+        # Run 20 runs.
+        res = client.schedule_adhoc("now", {"program": {"type": "no-op"}}, count=20)
+        run_ids = {r["run_id"] for r in res}
+        for run_id in run_ids:
+            inst.wait_run(run_id)
+
+        time.sleep(1)
+
+        # Archive, with a max age of 1 s but a count of only 5: fewer than the
+        # eligible runs, so archiving is truncated.
+        res = client.schedule_adhoc(
+            "now",
+            {
+                "program": {
+                    "type": "apsis.program.internal.archive.ArchiveProgram",
+                    "age": 1,
+                    "count": 5,
+                    "path": str(path),
+                },
+            },
+        )
+        truncated_run_id = res["run_id"]
+        res = inst.wait_run(truncated_run_id)
+        # The run failed loudly, because eligible runs remain.
+        assert res["state"] == "failure"
+        # The failure message explains why: count 5 ran out with 15 runs left.
+        log = client.get_run_log(truncated_run_id)
+        assert any("count 5 exhausted with 15 eligible runs remaining" in e["message"] for e in log)
+        # The archived runs are still reported.
+        assert res["meta"]["program"]["run count"] == 5
+
+        # A follow-up archive with a large enough count clears the rest and
+        # succeeds.
+        res = client.schedule_adhoc(
+            "now",
+            {
+                "program": {
+                    "type": "apsis.program.internal.archive.ArchiveProgram",
+                    "age": 1,
+                    "count": 100,
+                    "path": str(path),
+                },
+            },
+        )
+        res = inst.wait_run(res["run_id"])
+        # Count was not exhausted, so the run succeeds.
+        assert res["state"] == "success"
+
+
 def test_clean_up_jobs(tmp_path):
     path = tmp_path / "archive.db"
     job_dir = tmp_path / "jobs"


### PR DESCRIPTION
## Problem

If the archive `count` is too small, `ArchiveProgram` silently archives up to `count` runs and succeeds, leaving eligible runs un-archived. The Apsis database then grows without bound, and there's no signal that `count` needs raising.

## Change

When `count` is exhausted while eligible runs still remain, the run now **fails** with an explanatory message. The archived runs are still reported in the run metadata.

This surfaces a too-small `count` (or too-infrequent a schedule) loudly, instead of accumulating a backlog.

## Tests
Added `test_archive_truncated`: verifies the run fails with the expected message, reports the archived runs, and that a follow-up with a large enough `count` succeeds.
