### PR TITLE
Bugfix: don't drop scheduled runs when the clock outruns them

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -26,6 +26,7 @@ config file.
       since: null               # now, or YYYY-MM-DDTHH:MM:SSZ
       max_age: null             # seconds
       horizon: 86400            # seconds
+      clock_margin: 1800        # duration
 
     waiting:
       max_time: null            # duration
@@ -93,6 +94,18 @@ than this.  This prevents very old runs from running spuriously.
 
 `schedule.horizon` specifies how far forward in time, in seconds, to schedule new
 runs.
+
+`schedule.clock_margin` specifies how far before the stored schedule time to
+start scheduling runs on startup.  Apsis records the time through which it has
+started scheduled runs, but it does so before those runs are stored, so if Apsis
+stops abruptly the recorded time can be later than the last run that was
+actually stored.  Without a margin, runs in that gap are never started.
+
+Apsis does not create a run for a schedule time if a run for the same job, args,
+and schedule time already exists, so the margin does not cause runs to be
+started twice.  Note, however, that a job added while Apsis was down has no
+existing runs, so its runs are created back to the margin; keep the margin small
+enough that this is acceptable.  Set to 0 to disable.
 
 
 Waiting

--- a/python/apsis/apsis.py
+++ b/python/apsis/apsis.py
@@ -16,6 +16,7 @@ from .host_group import config_host_groups
 from .jobs import Jobs, load_jobs_dir, diff_jobs_dirs
 from .lib.api import run_to_summary_jso
 from .lib.asyn import TaskGroup, Publisher, KeyPublisher
+from .lib.parse import parse_duration
 from .lib.py import more_gc_stats
 from .lib.sys import to_signal
 from .output import OutputStore
@@ -110,12 +111,32 @@ class Apsis:
         # Continue scheduling from the last time we handled scheduled jobs.
         # FIXME: Rename: schedule horizon?
         stop_time = db.clock_db.get_time()
+
+        # The clock is advanced before the runs it covers are persisted, so
+        # after a crash it can be ahead of the runs that actually reached the
+        # database, and those runs would never be scheduled again.  Start a
+        # little earlier than the clock to cover that skew, and rely on the
+        # schedule-time check in the scheduler to avoid creating a run that
+        # already exists.
+        #
+        # The skew is bounded by how long the scheduled loop went between
+        # advancing the clock and persisting the runs it had popped, so a modest
+        # margin is enough.  Keep it modest: the margin is also how far back a
+        # job added while Apsis was down is scheduled, and those runs have no
+        # existing counterpart to suppress them.
+        margin = parse_duration(cfg.get("schedule", {}).get("clock_margin", 1800))
+        assert margin >= 0
+        if margin > 0:
+            log.info(f"scheduling from {stop_time - margin}: clock {stop_time} - {margin} s")
+            stop_time -= margin
+
         self.scheduler = Scheduler(
             cfg,
             self.jobs,
             # All runs scheduled by the scheduler are expected.
             partial(self.schedule, expected=True),
             stop_time,
+            get_schedule_times=self.__get_schedule_times,
         )
 
         self.scheduled = ScheduledRuns(db.clock_db, self.scheduler.get_scheduler_time, self._wait)
@@ -212,6 +233,20 @@ class Apsis:
 
         # We're running now.
         self.running_flag.set()
+
+    def __get_schedule_times(self):
+        """
+        Returns nominal schedule times of runs that already exist.
+
+        Used by the scheduler to avoid creating a second run for a schedule
+        time that has already been handled.  See `RunStore.get_schedule_times`.
+        """
+        # Bound the query by the earliest schedule time the scheduler can
+        # revisit.  A run that has started has a timestamp at or after its
+        # schedule time, so any started run with a schedule time in the
+        # scheduling window also has a timestamp in it, and is found.  Runs that
+        # haven't started are in memory, which this bound doesn't apply to.
+        return self.run_store.get_schedule_times(min_timestamp=self.scheduler.get_scheduler_time())
 
     def _wait(self, run):
         """

--- a/python/apsis/runs.py
+++ b/python/apsis/runs.py
@@ -634,6 +634,45 @@ class RunStore:
             min_timestamp=min_ts,
         )
 
+    def get_schedule_times(self, *, min_timestamp):
+        """
+        Returns the nominal schedule times of runs created from job schedules.
+
+        Used to avoid recreating a run that already exists for a given nominal
+        schedule time.  See `Apsis.schedule`.
+
+        Covers in-memory runs (expected and active) as well as persisted runs,
+        since a scheduled expected run is not persisted until it starts.
+
+        :param min_timestamp:
+          Ignore runs older than this.  Bounds the work; runs older than this
+          are not candidates for rescheduling anyway.
+        :return:
+          Mapping from `(job_id, canonical args JSON)` to the set of nominal
+          schedule times for which a run exists, in any state.
+        """
+        from .sqlite import canonical_args_json
+
+        res = {}
+
+        def add(job_id, args_json, time):
+            if time is None:
+                # Nothing to key on.
+                return
+            res.setdefault((job_id, args_json), set()).add(time)
+
+        # In-memory runs: expected (scheduled, not yet persisted) and active.
+        for run in itertools.chain(self.__expected_runs.values(), self.__active_runs.values()):
+            add(run.inst.job_id, canonical_args_json(run.inst.args), run.times.get("schedule"))
+
+        # Persisted runs, including finished ones.
+        for job_id, args_json, time in self.__run_db.query_schedule_times(
+            min_timestamp=min_timestamp
+        ):
+            add(job_id, args_json, time)
+
+        return res
+
     def get_stats(self):
         # Note: deliberately no DB count here.  Counting runs in the lookback window
         # requires a query over the runs table, which has no index on timestamp and

--- a/python/apsis/runs.py
+++ b/python/apsis/runs.py
@@ -1,4 +1,4 @@
-from collections import namedtuple
+from collections import Counter, namedtuple
 import itertools
 import jinja2
 import logging
@@ -636,7 +636,7 @@ class RunStore:
 
     def get_schedule_times(self, *, min_timestamp):
         """
-        Returns the nominal schedule times of runs created from job schedules.
+        Counts runs by nominal schedule time.
 
         Used to avoid recreating a run that already exists for a given nominal
         schedule time.  See `Apsis.schedule`.
@@ -644,12 +644,17 @@ class RunStore:
         Covers in-memory runs (expected and active) as well as persisted runs,
         since a scheduled expected run is not persisted until it starts.
 
+        Counts rather than merely noting presence, since a job may have several
+        schedules that produce the same schedule time and args, and each is a
+        run in its own right.
+
         :param min_timestamp:
           Ignore runs older than this.  Bounds the work; runs older than this
           are not candidates for rescheduling anyway.
         :return:
-          Mapping from `(job_id, canonical args JSON)` to the set of nominal
-          schedule times for which a run exists, in any state.
+          Mapping from `(job_id, canonical args JSON)` to a mapping from nominal
+          schedule time to the number of runs with that schedule time, in any
+          state.
         """
         from .sqlite import canonical_args_json
 
@@ -659,7 +664,8 @@ class RunStore:
             if time is None:
                 # Nothing to key on.
                 return
-            res.setdefault((job_id, args_json), set()).add(time)
+            times = res.setdefault((job_id, args_json), Counter())
+            times[time] += 1
 
         # In-memory runs: expected (scheduled, not yet persisted) and active.
         for run in itertools.chain(self.__expected_runs.values(), self.__active_runs.values()):

--- a/python/apsis/scheduled.py
+++ b/python/apsis/scheduled.py
@@ -130,7 +130,6 @@ class ScheduledRuns:
                         # Take it out of the entries dict.
                         assert self.__scheduled.pop(entry.run) is entry
                         ready.add(entry.run)
-                self.__clock_db.set_time(time)
 
                 if len(ready) > 0:
                     log.debug(f"{len(ready)} runs ready")
@@ -140,6 +139,13 @@ class ScheduledRuns:
                         # yield back to the event loop to prevent hanging it when many runs are started at the same time
                         # e.g. at the top of the hour
                         await asyncio.sleep(0)
+
+                # Advance the clock only once the runs it accounts for have been
+                # started, and so persisted.  If we stop before that, the clock
+                # still precedes them and they are scheduled again on startup;
+                # the scheduler skips the ones that already exist.  Advancing it
+                # first would leave them neither stored nor scheduled again.
+                self.__clock_db.set_time(time)
 
                 next_time = time + self.LOOP_TIME
                 if len(self.__heap) > 0:

--- a/python/apsis/scheduler.py
+++ b/python/apsis/scheduler.py
@@ -4,6 +4,7 @@ import logging
 from ora import Time, now
 
 from .runs import Instance
+from .sqlite import canonical_args_json
 from apsis.lib.parse import parse_duration
 
 log = logging.getLogger(__name__)
@@ -39,12 +40,17 @@ class Scheduler:
     Does not own any runs.
     """
 
-    def __init__(self, cfg, jobs, schedule, stop):
+    def __init__(self, cfg, jobs, schedule, stop, *, get_schedule_times=None):
         """
         :param jobs:
           Jobs object.
         :param schedule:
           Function of `time, run` that schedules a run.
+        :param get_schedule_times:
+          Function of no args returning a mapping from `(job_id, args JSON)` to
+          the set of nominal schedule times for which a run already exists.
+          Used to avoid recreating runs after a restart.  If none, no such
+          check is made.
         """
         cfg = cfg.get("schedule", {})
 
@@ -68,6 +74,7 @@ class Scheduler:
         self.__schedule = schedule
         self.__horizon = horizon
         self.__max_age = max_age
+        self.__get_schedule_times = get_schedule_times
 
     def set_jobs(self, jobs):
         """
@@ -90,10 +97,30 @@ class Scheduler:
             return
 
         log.debug(f"scheduling runs until {stop}")
+
+        # Nominal schedule times of runs that already exist, so that we don't
+        # create a second run for a schedule time we already handled.  Only
+        # needed when scheduling into the past, i.e. catching up after
+        # downtime; in steady state the window is in the future and empty.
+        if self.__get_schedule_times is not None and self.__stop < now():
+            existing = self.__get_schedule_times()
+            log.info(f"scheduling from {self.__stop}: {len(existing)} existing run keys")
+        else:
+            existing = None
+
         n = 0
+        skipped = 0
         for job in self.__jobs.get_jobs():
             items = get_insts_to_schedule(job, self.__stop, stop)
             for sched_time, stop_time, inst in items:
+                if existing is not None and sched_time in existing.get(
+                    (inst.job_id, canonical_args_json(inst.args)), ()
+                ):
+                    # A run for this job, args, and schedule time already
+                    # exists; don't create another.
+                    skipped += 1
+                    continue
+
                 await self.__schedule(sched_time, inst, stop_time=stop_time)
                 # using modulo instead of batching a generator because reducing allocations actually matters here for
                 # because of GC pressure
@@ -104,6 +131,9 @@ class Scheduler:
                     # make it a long wait until the scheduler will respond to network requests. The number 5 was chosen
                     # after measuring startup times.
                     await asyncio.sleep(0)
+
+        if skipped > 0:
+            log.info(f"skipped {skipped} runs that already exist")
 
         self.__stop = stop
 

--- a/python/apsis/scheduler.py
+++ b/python/apsis/scheduler.py
@@ -98,10 +98,11 @@ class Scheduler:
 
         log.debug(f"scheduling runs until {stop}")
 
-        # Nominal schedule times of runs that already exist, so that we don't
-        # create a second run for a schedule time we already handled.  Only
-        # needed when scheduling into the past, i.e. catching up after
-        # downtime; in steady state the window is in the future and empty.
+        # Counts of runs that already exist, by job, args, and nominal schedule
+        # time, so that we don't create a second run for a schedule time we
+        # already handled.  Only needed when scheduling into the past, i.e.
+        # catching up after downtime; in steady state the window is in the
+        # future, where no run exists yet.
         if self.__get_schedule_times is not None and self.__stop < now():
             existing = self.__get_schedule_times()
             log.info(f"scheduling from {self.__stop}: {len(existing)} existing run keys")
@@ -113,13 +114,17 @@ class Scheduler:
         for job in self.__jobs.get_jobs():
             items = get_insts_to_schedule(job, self.__stop, stop)
             for sched_time, stop_time, inst in items:
-                if existing is not None and sched_time in existing.get(
-                    (inst.job_id, canonical_args_json(inst.args)), ()
-                ):
-                    # A run for this job, args, and schedule time already
-                    # exists; don't create another.
-                    skipped += 1
-                    continue
+                if existing is not None:
+                    # Account for each existing run against one schedule that
+                    # would produce it.  A job may have several schedules that
+                    # produce the same schedule time and args, in which case
+                    # each is a run of its own, so match them up one for one
+                    # rather than skipping every schedule that collides.
+                    times = existing.get((inst.job_id, canonical_args_json(inst.args)))
+                    if times is not None and times.get(sched_time, 0) > 0:
+                        times[sched_time] -= 1
+                        skipped += 1
+                        continue
 
                 await self.__schedule(sched_time, inst, stop_time=stop_time)
                 # using modulo instead of batching a generator because reducing allocations actually matters here for

--- a/python/apsis/sqlite.py
+++ b/python/apsis/sqlite.py
@@ -575,6 +575,29 @@ class RunDB:
         )
         return runs
 
+    def query_schedule_times(self, *, min_timestamp=None):
+        """
+        Returns `(job_id, args, schedule_time)` for runs, without building
+        `Run` objects.
+
+        Only the nominal schedule time is extracted from the `times` column,
+        which makes this much cheaper than `query()` for the whole table: no
+        program, conds, or actions are deserialized.
+
+        :return:
+          Iterator of `(job_id, args_json, schedule_time)`, where `args_json`
+          is the canonical args JSON and `schedule_time` may be `None` if the
+          run has no schedule time.
+        """
+        query = sa.select([TBL_RUNS.c.job_id, TBL_RUNS.c.args, TBL_RUNS.c.times])
+        if min_timestamp is not None:
+            query = query.where(TBL_RUNS.c.timestamp >= dump_time(min_timestamp))
+
+        with self.__engine.connect() as conn:
+            for job_id, args_json, times_json in conn.execute(query):
+                time = ujson.loads(times_json).get("schedule")
+                yield job_id, args_json, None if time is None else ora.Time(time)
+
     def count_runs(
         self,
         *,

--- a/test/unit/test_schedule_reconcile.py
+++ b/test/unit/test_schedule_reconcile.py
@@ -9,6 +9,7 @@ which a run already exists.
 """
 
 import asyncio
+from collections import Counter
 import ora
 import pytest
 
@@ -23,21 +24,24 @@ INTERVAL = 300
 
 class _Job:
     """
-    A job with a single interval schedule and no params.
+    A job with `count` identical interval schedules and no params.
+
+    More than one schedule produces the same schedule time and args, as a job
+    with overlapping schedules does; each is a run in its own right.
     """
 
     job_id = JOB_ID
     params = frozenset()
 
-    def __init__(self):
+    def __init__(self, count=1):
         from apsis.schedule.interval import IntervalSchedule
 
-        self.schedules = [IntervalSchedule(INTERVAL, {})]
+        self.schedules = [IntervalSchedule(INTERVAL, {}) for _ in range(count)]
 
 
 class _Jobs:
-    def __init__(self):
-        self.__jobs = [_Job()]
+    def __init__(self, schedules=1):
+        self.__jobs = [_Job(schedules)]
 
     def get_jobs(self):
         return self.__jobs
@@ -47,12 +51,12 @@ class _Recorder:
     """
     Stands in for `Apsis.schedule`, recording what would be created.
 
-    Also serves as the store of existing runs, keyed as
+    Also serves as the store of existing runs, keyed and counted as
     `RunStore.get_schedule_times` does.
     """
 
     def __init__(self):
-        # Nominal schedule times of runs that exist.
+        # Counts of runs that exist, by key and schedule time.
         self.existing = {}
         # Schedule times passed to schedule(), in order.
         self.created = []
@@ -60,11 +64,13 @@ class _Recorder:
         self.crash_after = None
 
     def get_schedule_times(self):
-        return self.existing
+        # A fresh copy each call, as the real callback returns; the scheduler
+        # decrements the counts it is given.
+        return {key: Counter(times) for key, times in self.existing.items()}
 
-    def add_existing(self, time, args={}):
+    def add_existing(self, time, args={}, count=1):
         key = (JOB_ID, canonical_args_json(args))
-        self.existing.setdefault(key, set()).add(time)
+        self.existing.setdefault(key, Counter())[time] += count
 
     async def schedule(self, time, inst, *, stop_time=None):
         if self.crash_after is not None and len(self.created) >= self.crash_after:
@@ -80,10 +86,10 @@ class _Crash(BaseException):
     """
 
 
-def _scheduler(recorder, stop, *, reconcile=True):
+def _scheduler(recorder, stop, *, reconcile=True, schedules=1):
     return Scheduler(
         {"schedule": {}},
-        _Jobs(),
+        _Jobs(schedules),
         recorder.schedule,
         stop,
         get_schedule_times=(recorder.get_schedule_times if reconcile else None),
@@ -261,6 +267,79 @@ async def test_no_check_when_scheduling_future():
 
     assert calls == 0, "existing-run lookup should be skipped for future windows"
     assert len(rec.created) > 0
+
+
+@pytest.mark.asyncio
+async def test_overlapping_schedules_all_created():
+    """
+    Tests that a job whose schedules overlap gets a run for each.
+
+    Two schedules of a job may produce the same schedule time and args, for
+    instance schedules on different calendars that share a date.  Each is a run
+    in its own right, so the check must not collapse them into one.
+    """
+    now = ora.now()
+    start = now - 3600
+    expected = _boundaries(start, now)
+
+    rec = _Recorder()
+    await _scheduler(rec, start, schedules=3).schedule(now)
+
+    counts = Counter(rec.created)
+    assert sorted(counts) == expected
+    assert all(c == 3 for c in counts.values()), f"expected 3 runs each, got {counts}"
+
+
+@pytest.mark.asyncio
+async def test_overlapping_schedules_partial_existing():
+    """
+    Tests that only the missing runs of an overlapping schedule are created.
+
+    After a crash partway through, some of the runs for a schedule time exist
+    and the rest don't.  Each existing run accounts for one schedule, so the
+    remainder are still created.
+    """
+    now = ora.now()
+    start = now - 3600
+    expected = _boundaries(start, now)
+
+    rec = _Recorder()
+    # One of the three runs for each schedule time already exists.
+    for time in expected:
+        rec.add_existing(time)
+
+    await _scheduler(rec, start, schedules=3).schedule(now)
+
+    # Two more created for each, for three in total.
+    counts = Counter(rec.created)
+    assert sorted(counts) == expected
+    assert all(c == 2 for c in counts.values()), f"expected 2 more each, got {counts}"
+
+
+@pytest.mark.asyncio
+async def test_overlapping_schedules_crash_converges():
+    """
+    Tests that overlapping schedules converge across crashes.
+
+    Regression test: matching on the presence of a schedule time rather than
+    counting dropped every run but the first for each schedule time.
+    """
+    now = ora.now()
+    start = now - 3600
+    expected = _boundaries(start, now)
+
+    rec = _Recorder()
+    for crash_after in (1, 4, 9):
+        rec.crash_after = len(rec.created) + crash_after
+        with pytest.raises(_Crash):
+            await _scheduler(rec, start, schedules=3).schedule(now)
+
+    rec.crash_after = None
+    await _scheduler(rec, start, schedules=3).schedule(now)
+
+    counts = Counter(rec.created)
+    assert sorted(counts) == expected
+    assert all(c == 3 for c in counts.values()), f"expected 3 runs each, got {counts}"
 
 
 if __name__ == "__main__":

--- a/test/unit/test_schedule_reconcile.py
+++ b/test/unit/test_schedule_reconcile.py
@@ -1,0 +1,267 @@
+"""
+Tests that the scheduler doesn't recreate runs that already exist.
+
+The clock (`ClockDB`) is advanced before the runs it covers are persisted, so
+after a crash it can be ahead of the runs that actually reached the database.
+Scheduling from the clock alone therefore silently drops those runs.  The
+scheduler instead schedules from further back and skips any schedule time for
+which a run already exists.
+"""
+
+import asyncio
+import ora
+import pytest
+
+from apsis.scheduler import Scheduler
+from apsis.sqlite import canonical_args_json
+
+# -------------------------------------------------------------------------------
+
+JOB_ID = "job"
+INTERVAL = 300
+
+
+class _Job:
+    """
+    A job with a single interval schedule and no params.
+    """
+
+    job_id = JOB_ID
+    params = frozenset()
+
+    def __init__(self):
+        from apsis.schedule.interval import IntervalSchedule
+
+        self.schedules = [IntervalSchedule(INTERVAL, {})]
+
+
+class _Jobs:
+    def __init__(self):
+        self.__jobs = [_Job()]
+
+    def get_jobs(self):
+        return self.__jobs
+
+
+class _Recorder:
+    """
+    Stands in for `Apsis.schedule`, recording what would be created.
+
+    Also serves as the store of existing runs, keyed as
+    `RunStore.get_schedule_times` does.
+    """
+
+    def __init__(self):
+        # Nominal schedule times of runs that exist.
+        self.existing = {}
+        # Schedule times passed to schedule(), in order.
+        self.created = []
+        # If set, raise after this many creations, to simulate a crash.
+        self.crash_after = None
+
+    def get_schedule_times(self):
+        return self.existing
+
+    def add_existing(self, time, args={}):
+        key = (JOB_ID, canonical_args_json(args))
+        self.existing.setdefault(key, set()).add(time)
+
+    async def schedule(self, time, inst, *, stop_time=None):
+        if self.crash_after is not None and len(self.created) >= self.crash_after:
+            raise _Crash
+        self.created.append(time)
+        # A created run exists from now on, as it would in the run store.
+        self.add_existing(time, inst.args)
+
+
+class _Crash(BaseException):
+    """
+    Simulates a process crash partway through scheduling.
+    """
+
+
+def _scheduler(recorder, stop, *, reconcile=True):
+    return Scheduler(
+        {"schedule": {}},
+        _Jobs(),
+        recorder.schedule,
+        stop,
+        get_schedule_times=(recorder.get_schedule_times if reconcile else None),
+    )
+
+
+def _boundaries(start, stop):
+    """
+    Returns the interval-schedule times in `[start, stop)`.
+    """
+    epoch = ora.Time.EPOCH
+    first = int((start - epoch) // INTERVAL) * INTERVAL
+    times = []
+    t = epoch + first
+    while t < stop:
+        if t >= start:
+            times.append(t)
+        t += INTERVAL
+    return times
+
+
+# -------------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_existing_runs():
+    """
+    Tests that with no existing runs, every schedule time is created.
+    """
+    now = ora.now()
+    start = now - 3600
+    rec = _Recorder()
+    await _scheduler(rec, start).schedule(now)
+
+    assert rec.created == _boundaries(start, now)
+
+
+@pytest.mark.asyncio
+async def test_skips_existing_runs():
+    """
+    Tests that a schedule time with an existing run is not scheduled again.
+
+    This is the case after a crash: the clock is ahead of some runs, so the
+    scheduler revisits schedule times it has already handled.
+    """
+    now = ora.now()
+    start = now - 3600
+    expected = _boundaries(start, now)
+
+    rec = _Recorder()
+    # Half the runs already exist, as they would after a partial catch-up.
+    for time in expected[::2]:
+        rec.add_existing(time)
+
+    await _scheduler(rec, start).schedule(now)
+
+    # Only the missing ones are created, and nothing is created twice.
+    assert rec.created == expected[1::2]
+    assert len(set(rec.created)) == len(rec.created)
+
+
+@pytest.mark.asyncio
+async def test_all_runs_exist():
+    """
+    Tests that nothing is scheduled when every run already exists.
+    """
+    now = ora.now()
+    start = now - 3600
+    rec = _Recorder()
+    for time in _boundaries(start, now):
+        rec.add_existing(time)
+
+    await _scheduler(rec, start).schedule(now)
+
+    assert rec.created == []
+
+
+@pytest.mark.asyncio
+async def test_repeated_crashes_converge():
+    """
+    Tests that repeated crashes while catching up neither lose nor duplicate.
+
+    Each pass crashes partway through, as Apsis did when it was restarted
+    repeatedly while working through a backlog.
+    """
+    now = ora.now()
+    start = now - 6 * 3600
+    expected = _boundaries(start, now)
+
+    rec = _Recorder()
+
+    for crash_after in (10, 25, 5):
+        rec.crash_after = len(rec.created) + crash_after
+        with pytest.raises(_Crash):
+            await _scheduler(rec, start).schedule(now)
+
+    # Finally, a pass that completes.
+    rec.crash_after = None
+    await _scheduler(rec, start).schedule(now)
+
+    # Every schedule time created exactly once, in spite of the crashes.
+    assert sorted(rec.created) == expected
+    assert len(set(rec.created)) == len(rec.created)
+
+
+@pytest.mark.asyncio
+async def test_without_reconcile_duplicates():
+    """
+    Tests that without the check, revisiting schedule times duplicates runs.
+
+    Guards the test setup: shows these tests would catch a regression.
+    """
+    now = ora.now()
+    start = now - 3600
+    expected = _boundaries(start, now)
+
+    rec = _Recorder()
+    for time in expected:
+        rec.add_existing(time)
+
+    await _scheduler(rec, start, reconcile=False).schedule(now)
+
+    # Every run is created a second time.
+    assert rec.created == expected
+
+
+@pytest.mark.asyncio
+async def test_args_distinguish_runs():
+    """
+    Tests that runs differing only in args are not conflated.
+
+    A job scheduled per host has several runs at the same schedule time; an
+    existing run for one host must not suppress the others.
+    """
+    now = ora.now()
+    start = now - 3600
+    expected = _boundaries(start, now)
+
+    rec = _Recorder()
+    # Existing runs carry args that the job doesn't produce, so they must not
+    # match any candidate.
+    for time in expected:
+        rec.add_existing(time, {"host": "other"})
+
+    await _scheduler(rec, start).schedule(now)
+
+    # None of the existing runs match, so all candidates are created.
+    assert rec.created == expected
+
+
+@pytest.mark.asyncio
+async def test_no_check_when_scheduling_future():
+    """
+    Tests that the check is skipped when scheduling only future times.
+
+    In steady state the window is ahead of now, where no run can exist yet, so
+    the scheduler shouldn't pay for the lookup.
+    """
+    now = ora.now()
+    calls = 0
+
+    rec = _Recorder()
+    get = rec.get_schedule_times
+
+    def counting_get():
+        nonlocal calls
+        calls += 1
+        return get()
+
+    rec.get_schedule_times = counting_get
+
+    # Schedule a window starting in the future.
+    scheduler = _scheduler(rec, now + 600)
+    await scheduler.schedule(now + 3600)
+
+    assert calls == 0, "existing-run lookup should be skipped for future windows"
+    assert len(rec.created) > 0
+
+
+if __name__ == "__main__":
+    asyncio.run(test_repeated_crashes_converge())


### PR DESCRIPTION
(Related issue: #iac/issues/1973)

