### PR TITLE
Bugfix: don't drop run metadata when a program result has none

### DIFF
--- a/python/apsis/running.py
+++ b/python/apsis/running.py
@@ -46,6 +46,19 @@ async def _maybe_compress(outputs, *, compression="br", min_size=16384):
     return dict(zip(outputs.keys(), o))
 
 
+def _program_meta(meta):
+    """
+    Returns a run metadata update for program metadata `meta`.
+
+    A run's program metadata is replaced by, rather than merged with, the
+    metadata of each program update, so a program that reports no metadata must
+    produce no update at all.  Otherwise it would erase what is already known
+    about the program, such as the host and pid of a process that Apsis has
+    lost track of.
+    """
+    return {"program": meta} if meta else {}
+
+
 async def _process_updates(apsis, run):
     """
     Processes program `updates` for `run` until the program is finished.
@@ -65,7 +78,7 @@ async def _process_updates(apsis, run):
                     # Handle intermediate updates during startup
                     if update.outputs is not None:
                         apsis._update_output_data(run, update.outputs, False)
-                    apsis._update_metadata(run, {"program": update.meta})
+                    apsis._update_metadata(run, _program_meta(update.meta))
 
                 case ProgramRunning() as running:
                     apsis.run_log.record(run, "running")
@@ -73,7 +86,7 @@ async def _process_updates(apsis, run):
                         run,
                         State.running,
                         run_state=running.run_state,
-                        meta={"program": running.meta},
+                        meta=_program_meta(running.meta),
                         times=running.times,
                     )
                     break
@@ -84,7 +97,7 @@ async def _process_updates(apsis, run):
                     apsis._transition(
                         run,
                         State.error,
-                        meta={"program": error.meta},
+                        meta=_program_meta(error.meta),
                         times=error.times,
                     )
                     return
@@ -117,8 +130,7 @@ async def _process_updates(apsis, run):
                 case ProgramUpdate() as update:
                     if update.outputs is not None:
                         apsis._update_output_data(run, update.outputs, False)
-                    if update.meta is not None:
-                        apsis._update_metadata(run, {"program": update.meta})
+                    apsis._update_metadata(run, _program_meta(update.meta))
 
                 case ProgramSuccess() as success:
                     apsis.run_log.record(run, "success")
@@ -126,7 +138,7 @@ async def _process_updates(apsis, run):
                     apsis._transition(
                         run,
                         State.success,
-                        meta={"program": success.meta},
+                        meta=_program_meta(success.meta),
                         times=success.times,
                     )
 
@@ -137,7 +149,7 @@ async def _process_updates(apsis, run):
                     apsis._transition(
                         run,
                         State.failure,
-                        meta={"program": failure.meta},
+                        meta=_program_meta(failure.meta),
                         times=failure.times,
                     )
 
@@ -147,7 +159,7 @@ async def _process_updates(apsis, run):
                     apsis._transition(
                         run,
                         State.error,
-                        meta={"program": error.meta},
+                        meta=_program_meta(error.meta),
                         times=error.times,
                     )
 

--- a/test/int/procstar/test_program.py
+++ b/test/int/procstar/test_program.py
@@ -50,6 +50,38 @@ def test_reconnect():
         assert len(agent.client.get_procs()) == 0
 
 
+def test_reconnect_failed_keeps_metadata():
+    """
+    Tests that a run keeps its metadata when Apsis can't reconnect to it.
+
+    A run whose process Apsis has lost track of is precisely the run whose
+    metadata is needed, to go find the process, so the metadata must survive
+    the transition to error.
+    """
+    with ApsisService(job_dir=JOB_DIR) as svc, svc.agent() as agent:
+        run_id = svc.client.schedule("sleep", {"time": 30})["run_id"]
+        # Wait for the run to start; only a running run has program metadata.
+        assert svc.wait_for_run_to_start(run_id)["state"] == "running"
+        meta = svc.client.get_run(run_id)["meta"]["program"]
+        assert meta["procstar_proc_id"] is not None
+        assert meta["procstar_conn"]["conn_id"] == agent.conn_id
+
+        # Take Apsis down, then restart the agent with a new connection ID, so
+        # that Apsis can't reconnect to the run's process.
+        svc.stop_serve()
+        agent.restart()
+        svc.start_serve()
+        svc.wait_for_serve()
+
+        # The run errors, since Apsis can't reconnect to it.
+        res = svc.wait_run(run_id, timeout=30)
+        assert res["state"] == "error"
+        assert any("reconnect failed" in r["message"] for r in svc.client.get_run_log(run_id))
+
+        # Its metadata is intact.
+        assert svc.client.get_run(run_id)["meta"]["program"] == meta
+
+
 def test_reconnect_many(num=256):
     """
     Tests reconnecting to many running runs after Apsis restart.

--- a/test/unit/test_running.py
+++ b/test/unit/test_running.py
@@ -1,0 +1,215 @@
+"""
+Tests processing of program updates for a run, in `apsis.running`.
+"""
+
+import ora
+import pytest
+
+from apsis.apsis import Apsis
+from apsis.lib import memo
+from apsis.program.base import (
+    ProgramError,
+    ProgramFailure,
+    ProgramRunning,
+    ProgramSuccess,
+    ProgramUpdate,
+    RunningProgram,
+)
+from apsis.running import _process_updates
+from apsis.runs import Instance, Run
+from apsis.states import State
+
+# -------------------------------------------------------------------------------
+
+RUN_STATE = {"conn_id": "conn0", "proc_id": "proc0"}
+
+# Metadata a Procstar program reports once the process is running.
+PROGRAM_META = {
+    "procstar_proc_id": "proc0",
+    "procstar_conn": {"conn_id": "conn0", "hostname": "host0"},
+    "proc_stat": {"pid": 12345},
+}
+
+
+class _FixedRunningProgram(RunningProgram):
+    """
+    Running program that yields a fixed sequence of updates.
+    """
+
+    def __init__(self, run_id, updates):
+        super().__init__(run_id)
+        self.__updates = updates
+
+    @memo.property
+    async def updates(self):
+        for update in self.__updates:
+            yield update
+
+
+class _RunLog:
+    def __init__(self):
+        self.messages = []
+
+    def record(self, run, message, **kw_args):
+        self.messages.append(str(message))
+
+    info = record
+    error = record
+
+    def exc(self, run, message=None, **kw_args):
+        self.messages.append(str(message))
+
+
+class _Publisher:
+    def __contains__(self, run_id):
+        return False
+
+    def publish(self, *args, **kw_args):
+        pass
+
+    def close(self, run_id):
+        pass
+
+
+class _RunStore:
+    def update(self, run, time):
+        pass
+
+
+class _FakeApsis:
+    """
+    Minimal stand-in for `Apsis`, wired to the real transition and metadata
+    logic, so that metadata semantics are tested for real.
+    """
+
+    _transition = Apsis._transition
+    _update_metadata = Apsis._update_metadata
+
+    # `Apsis._transition` uses these two private attributes; Python mangles
+    # their names with the class that defines the method, so provide them under
+    # the mangled names.  The db is used only for expected runs, which these
+    # tests don't create.
+    _Apsis__db = None
+    _Apsis__start_actions = staticmethod(lambda run: None)
+
+    def __init__(self, run, updates):
+        self.run_log = _RunLog()
+        self.run_store = _RunStore()
+        self.run_update_publisher = _Publisher()
+        self.summary_publisher = _Publisher()
+        self.output_update_publisher = _Publisher()
+        self.outputs = {}
+        self._running_programs = {run.run_id: _FixedRunningProgram(run.run_id, updates)}
+
+    def _update_output_data(self, run, outputs, persist):
+        self.outputs.update(outputs)
+
+
+def _make_run(updates):
+    """
+    Returns a run in the starting state, and a `_FakeApsis` to drive it.
+
+    :param updates:
+      The sequence of program updates to feed to the run.
+    """
+    run = Run(Instance("job", {}))
+    run.run_id = "r0"
+    apsis = _FakeApsis(run, updates)
+    apsis._transition(run, State.scheduled, times={"schedule": ora.now()})
+    apsis._transition(run, State.starting)
+    return apsis, run
+
+
+# -------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("result", "state"),
+    (
+        (ProgramSuccess(), State.success),
+        (ProgramFailure("exit code 1"), State.failure),
+        (ProgramError("reconnect failed: proc0: unknown connection: conn0"), State.error),
+    ),
+    ids=("success", "failure", "error"),
+)
+@pytest.mark.asyncio
+async def test_result_without_metadata_keeps_program_metadata(result, state):
+    """
+    A program result with no metadata of its own doesn't erase program metadata.
+
+    The error case is the reconnect failure: the run was running, so its
+    metadata records the host and pid of the process, then Apsis fails to
+    reconnect to the process and errors the run.  The metadata is exactly
+    what's needed to go find the abandoned process, so it must survive.
+    """
+    apsis, run = _make_run(
+        [
+            ProgramRunning(RUN_STATE, meta=PROGRAM_META),
+            result,
+        ]
+    )
+
+    await _process_updates(apsis, run)
+
+    assert run.state == state
+    assert run.meta["program"] == PROGRAM_META
+
+
+@pytest.mark.asyncio
+async def test_error_keeps_startup_metadata():
+    """
+    An error while starting doesn't erase metadata reported during startup.
+
+    A program may report metadata about resources it acquired before the
+    process is running, e.g. an AWS ECS task; erasing it leaks the resource.
+    """
+    STARTUP_META = {"aws_ecs": {"task_id": "task0", "cluster_name": "cluster0"}}
+    apsis, run = _make_run(
+        [
+            ProgramUpdate(meta=STARTUP_META),
+            ProgramError("start failed: proc0: no open connection in group"),
+        ]
+    )
+
+    await _process_updates(apsis, run)
+
+    assert run.state == State.error
+    assert run.meta["program"] == STARTUP_META
+
+
+@pytest.mark.asyncio
+async def test_update_without_metadata_keeps_program_metadata():
+    """
+    A program update with no metadata doesn't erase program metadata.
+    """
+    apsis, run = _make_run(
+        [
+            ProgramRunning(RUN_STATE, meta=PROGRAM_META),
+            ProgramUpdate(outputs={}),
+            ProgramSuccess(meta=PROGRAM_META),
+        ]
+    )
+
+    await _process_updates(apsis, run)
+
+    assert run.state == State.success
+    assert run.meta["program"] == PROGRAM_META
+
+
+@pytest.mark.asyncio
+async def test_result_metadata_replaces_program_metadata():
+    """
+    A program result with metadata of its own replaces the program metadata.
+    """
+    ERROR_META = {**PROGRAM_META, "status": {"exit_code": None, "signal": "SIGKILL"}}
+    apsis, run = _make_run(
+        [
+            ProgramRunning(RUN_STATE, meta=PROGRAM_META),
+            ProgramError("procstar: oh no", meta=ERROR_META),
+        ]
+    )
+
+    await _process_updates(apsis, run)
+
+    assert run.state == State.error
+    assert run.meta["program"] == ERROR_META


### PR DESCRIPTION
## Problem

A run can lose all of its program metadata, most visibly when it transitions to `error`.

Program metadata is applied as `run.meta.update({"program": msg.meta})`, which *replaces* the whole `program` value, and every program message defaults to `meta={}`. So a message that reports no metadata erases everything already known about the program. Three paths do exactly that: `reconnect failed` (`agent.py:549`), the generic `procstar: {exc}` handler when no result has arrived yet (`agent.py:678`), and `start failed` (`agent.py:515`, which for ECS erases the pre-start `aws_ecs` record).

Reproduced end to end — start a run, stop Apsis, restart the agent with a new connection ID, start Apsis. Apsis can't reconnect, errors the run, and `meta` becomes `{'job': {'labels': []}, 'program': {}}`, losing the agent host, connection ID, proc ID and pid: precisely what's needed to go find the process Apsis just lost track of.


## Fix

Distinguish "reported no metadata" from "reported empty metadata", and produce no update in the former case:

```python
def _program_meta(meta):
    return {"program": meta} if meta else {}
```

applied at the seven sites in `apsis/running.py` that turn a program message into a metadata update. For non-empty metadata the result is identical to before, so success, failure, intermediate results and ECS base metadata are unaffected; replace-vs-merge semantics are deliberately left alone. This also unifies the pre-existing `if update.meta is not None` guard, which the running loop had but the startup loop didn't.

## One behaviour change

For programs that never report metadata (`no-op`, internal `stats`), `meta.program` is now absent rather than `{}`. All in-repo consumers guard for this (`RunView.vue:79`, and no Python code indexes `meta["program"]` outside `running.py`), but an external consumer doing `run["meta"]["program"]` would need `.get()`.

## Tests

- `test/unit/test_running.py` drives the real `_process_updates` over fixed message sequences against a real `Run` and the real `Apsis._transition`/`_update_metadata`: a metadata-free `ProgramSuccess`/`ProgramFailure`/`ProgramError` keeps the metadata, an error during startup keeps `_pre_start` metadata, and a result *with* metadata still replaces it.
- `test/int/procstar/test_program.py::test_reconnect_failed_keeps_metadata` covers the reported failure for real.

With the `running.py` change reverted, 4 of the 6 unit tests and the integration test fail. Full suite: 491 passed (`test_stop.py::test_rerun_with_stop` is flaky on `main` too, on its `elapsed < 0.1` timing assertion).

## Not addressed

Sub-key loss under replace semantics: keys a later result omits still disappear — e.g. `proc_statm` is present while running and absent once terminated, since Procstar can't read `/proc/<pid>/statm` for a dead process. Merging would retain those but also keep stale snapshots on finished runs.
