### PR TITLE
Don't block the event loop while reloading jobs

### DIFF
--- a/python/apsis/jobs.py
+++ b/python/apsis/jobs.py
@@ -13,6 +13,7 @@ from .actions import Action
 from .actions.schedule import successor_from_jso
 from .cond import Condition
 from .exc import JobError, JobsDirErrors, SchemaError
+from .lib import itr
 from .lib.json import to_array, to_narray, check_schema
 from .lib.py import tupleize, format_ctor
 from .program import Program, NoOpProgram
@@ -156,7 +157,9 @@ def dump_yaml(file, job):
 
 def list_yaml_files(dir_path):
     dir_path = Path(dir_path)
-    for dir, _, names in os.walk(dir_path):
+    for dir, dirs, names in os.walk(dir_path):
+        # Don't go into hidden dirs (e.g. `.git`)
+        dirs[:] = [d for d in dirs if not d.startswith(".")]
         dir = Path(dir)
         paths = (dir / n for n in names if not n.startswith("."))
         paths = (p for p in paths if p.suffix == ".yaml")
@@ -269,12 +272,14 @@ async def load_jobs_dir(path, yaml_loader=None):
             exc.job_id = job_id
             return job_id, None, exc
 
-    for path, job_id in list_yaml_files(jobs_path):
-        _, job, exc = await load_job(path, job_id)
-        if job is not None:
-            jobs[job_id] = job
-        if exc is not None:
-            errors.append(exc)
+    for chunk in itr.chunks(list_yaml_files(jobs_path), 16):
+        for job_id, job, exc in await asyncio.gather(
+            *(load_job(path, job_id) for path, job_id in chunk)
+        ):
+            if job is not None:
+                jobs[job_id] = job
+            if exc is not None:
+                errors.append(exc)
 
     jobs_dir = JobsDir(jobs_path, jobs)
 

--- a/python/apsis/jobs.py
+++ b/python/apsis/jobs.py
@@ -13,7 +13,6 @@ from .actions import Action
 from .actions.schedule import successor_from_jso
 from .cond import Condition
 from .exc import JobError, JobsDirErrors, SchemaError
-from .lib import itr
 from .lib.json import to_array, to_narray, check_schema
 from .lib.py import tupleize, format_ctor
 from .program import Program, NoOpProgram
@@ -270,14 +269,12 @@ async def load_jobs_dir(path, yaml_loader=None):
             exc.job_id = job_id
             return job_id, None, exc
 
-    load_coros = [load_job(path, job_id) for path, job_id in list_yaml_files(jobs_path)]
-    for chunk in itr.chunks(load_coros, 100):
-        results = await asyncio.gather(*chunk)
-        for job_id, job, exc in results:
-            if job is not None:
-                jobs[job_id] = job
-            if exc is not None:
-                errors.append(exc)
+    for path, job_id in list_yaml_files(jobs_path):
+        _, job, exc = await load_job(path, job_id)
+        if job is not None:
+            jobs[job_id] = job
+        if exc is not None:
+            errors.append(exc)
 
     jobs_dir = JobsDir(jobs_path, jobs)
 

--- a/python/apsis/jobs.py
+++ b/python/apsis/jobs.py
@@ -157,11 +157,11 @@ def dump_yaml(file, job):
 
 def list_yaml_files(dir_path):
     dir_path = Path(dir_path)
-    for dir, dirs, names in os.walk(dir_path):
+    for root, dirs, files in os.walk(dir_path):
         # Don't go into hidden dirs (e.g. `.git`)
         dirs[:] = [d for d in dirs if not d.startswith(".")]
-        dir = Path(dir)
-        paths = (dir / n for n in names if not n.startswith("."))
+        root = Path(root)
+        paths = (root / n for n in files if not n.startswith("."))
         paths = (p for p in paths if p.suffix == ".yaml")
         for path in paths:
             job_id = str(path.with_suffix("").relative_to(dir_path))
@@ -223,6 +223,9 @@ class JobsDir:
         return jobs
 
 
+JOB_LOAD_BATCH_SIZE = 16
+
+
 async def load_jobs_dir(path, yaml_loader=None):
     """
     Attempts to loads jobs from a jobs dir.
@@ -272,7 +275,7 @@ async def load_jobs_dir(path, yaml_loader=None):
             exc.job_id = job_id
             return job_id, None, exc
 
-    for chunk in itr.chunks(list_yaml_files(jobs_path), 16):
+    for chunk in itr.chunks(list_yaml_files(jobs_path), JOB_LOAD_BATCH_SIZE):
         for job_id, job, exc in await asyncio.gather(
             *(load_job(path, job_id) for path, job_id in chunk)
         ):

--- a/test/unit/test_load_jobs_yield.py
+++ b/test/unit/test_load_jobs_yield.py
@@ -1,0 +1,109 @@
+"""
+Tests that `load_jobs_dir` stays cooperative: it walks and parses the jobs dir
+without blocking the event loop for the whole (potentially slow, NFS-backed)
+traversal.
+"""
+
+import asyncio
+import os
+import time
+
+import pytest
+
+import apsis.exc
+import apsis.jobs
+
+# -------------------------------------------------------------------------------
+
+
+def _write_job(path):
+    path.write_text("params: []\nprogram:\n  type: no-op\n")
+
+
+def _make_jobs_tree(root, n_dirs, per_dir=1):
+    for d in range(n_dirs):
+        sub = root / f"d{d}"
+        sub.mkdir()
+        for f in range(per_dir):
+            _write_job(sub / f"job{f}.yaml")
+
+
+@pytest.mark.asyncio
+async def test_load_jobs_dir_interleaves_slow_walk(tmp_path, monkeypatch):
+    """
+    A slow directory walk must not block the event loop for its whole duration.
+
+    We inject a synchronous per-directory delay (simulating slow NFS metadata
+    reads) and assert that a concurrent task still runs *between* directories,
+    so the worst single stall is about one directory's delay -- not the sum
+    over all directories (which is what eagerly consuming the walk would cost).
+    """
+    # 20 dirs keeps a wide margin between the cooperative worst stall
+    # (~2 dirs, due to the yaml-less root coalescing with the first) and
+    # the eager whole-walk stall, so the threshold is not flaky on CI.
+    n_dirs = 20
+    _make_jobs_tree(tmp_path, n_dirs)
+
+    delay = 0.02
+    real_walk = os.walk
+
+    def slow_walk(*args, **kwargs):
+        for entry in real_walk(*args, **kwargs):
+            # Simulate a slow scandir for each directory.
+            time.sleep(delay)
+            yield entry
+
+    monkeypatch.setattr(apsis.jobs.os, "walk", slow_walk)
+
+    gaps = []
+    stop = False
+
+    async def ticker():
+        last = time.perf_counter()
+        while not stop:
+            await asyncio.sleep(0)
+            now = time.perf_counter()
+            gaps.append(now - last)
+            last = now
+
+    task = asyncio.create_task(ticker())
+    # Let the ticker start and establish its baseline before the load begins,
+    # so it can observe a stall that happens at the very start of the walk.
+    await asyncio.sleep(0.01)
+    jobs_dir = await apsis.jobs.load_jobs_dir(tmp_path)
+    stop = True
+    await task
+
+    # All jobs loaded correctly through the sequential loop.
+    assert len(list(jobs_dir.get_jobs())) == n_dirs
+
+    # The whole walk costs ~n_dirs * delay.  If the loop were blocked for the
+    # entire walk (e.g. by consuming it eagerly into a list), the worst stall
+    # would approach that total.  Cooperative iteration bounds the worst stall
+    # to roughly a single directory's delay.
+    total_walk = delay * (n_dirs + 1)
+    assert max(gaps) < total_walk / 2, (
+        f"event loop blocked {max(gaps) * 1000:.0f}ms; whole walk is {total_walk * 1000:.0f}ms"
+    )
+
+
+@pytest.mark.asyncio
+async def test_load_jobs_dir_loads_all_jobs(tmp_path):
+    """The refactored loop still loads every job, with correct job ids."""
+    _make_jobs_tree(tmp_path, n_dirs=3, per_dir=4)
+    jobs_dir = await apsis.jobs.load_jobs_dir(tmp_path)
+    job_ids = {j.job_id for j in jobs_dir.get_jobs()}
+    assert job_ids == {f"d{d}/job{f}" for d in range(3) for f in range(4)}
+
+
+@pytest.mark.asyncio
+async def test_load_jobs_dir_reports_bad_yaml(tmp_path):
+    """A malformed job still surfaces as an error through the sequential loop."""
+    _write_job(tmp_path / "good.yaml")
+    # Valid YAML but missing the required `program`: raises SchemaError,
+    # which the loader collects rather than propagating.
+    (tmp_path / "bad.yaml").write_text("params: [x]\n")
+    with pytest.raises(apsis.exc.JobsDirErrors) as exc_info:
+        await apsis.jobs.load_jobs_dir(tmp_path)
+    assert len(exc_info.value.errors) == 1
+    assert exc_info.value.errors[0].job_id == "bad"

--- a/test/unit/test_load_jobs_yield.py
+++ b/test/unit/test_load_jobs_yield.py
@@ -34,17 +34,16 @@ async def test_load_jobs_dir_interleaves_slow_walk(tmp_path, monkeypatch):
     A slow directory walk must not block the event loop for its whole duration.
 
     We inject a synchronous per-directory delay (simulating slow NFS metadata
-    reads) and assert that a concurrent task still runs *between* directories,
-    so the worst single stall is about one directory's delay -- not the sum
-    over all directories (which is what eagerly consuming the walk would cost).
+    reads) and assert that a concurrent task still runs *between* batches, so the
+    worst stall is about one batch's worth of directories -- not the sum over all
+    directories (which is what eagerly consuming the whole walk would cost).
     """
-    # 20 dirs keeps a wide margin between the cooperative worst stall
-    # (~2 dirs, due to the yaml-less root coalescing with the first) and
-    # the eager whole-walk stall, so the threshold is not flaky on CI.
-    n_dirs = 20
+    # Many more dirs than the load batch (16) so the worst stall -- about one
+    # batch of walking -- stays well under the whole-walk time.
+    n_dirs = 64
     _make_jobs_tree(tmp_path, n_dirs)
 
-    delay = 0.02
+    delay = 0.005
     real_walk = os.walk
 
     def slow_walk(*args, **kwargs):
@@ -79,8 +78,8 @@ async def test_load_jobs_dir_interleaves_slow_walk(tmp_path, monkeypatch):
 
     # The whole walk costs ~n_dirs * delay.  If the loop were blocked for the
     # entire walk (e.g. by consuming it eagerly into a list), the worst stall
-    # would approach that total.  Cooperative iteration bounds the worst stall
-    # to roughly a single directory's delay.
+    # would approach that total.  Batched iteration bounds it to about one
+    # batch's worth of directories.
     total_walk = delay * (n_dirs + 1)
     assert max(gaps) < total_walk / 2, (
         f"event loop blocked {max(gaps) * 1000:.0f}ms; whole walk is {total_walk * 1000:.0f}ms"
@@ -94,6 +93,17 @@ async def test_load_jobs_dir_loads_all_jobs(tmp_path):
     jobs_dir = await apsis.jobs.load_jobs_dir(tmp_path)
     job_ids = {j.job_id for j in jobs_dir.get_jobs()}
     assert job_ids == {f"d{d}/job{f}" for d in range(3) for f in range(4)}
+
+
+@pytest.mark.asyncio
+async def test_load_jobs_dir_skips_hidden_dirs(tmp_path):
+    """Hidden dirs (e.g. `.git`) are not descended into."""
+    _write_job(tmp_path / "real.yaml")
+    git = tmp_path / ".git" / "objects"
+    git.mkdir(parents=True)
+    _write_job(git / "nope.yaml")
+    jobs_dir = await apsis.jobs.load_jobs_dir(tmp_path)
+    assert {j.job_id for j in jobs_dir.get_jobs()} == {"real"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This keeps reloading the jobs dir from freezing the scheduler.

First, it stops the reload from blocking the event loop. The old code pulled the whole directory listing into a list before awaiting anything, so the entire os.walk ran up front and froze the loop for several seconds on the NFS jobs dir. Now it walks the dir lazily and hands control back to the loop as it goes.

Second, it loads job files in batches of 16 instead of one at a time, so the reads and parses overlap. That makes the file loading part of the reload roughly 3x faster than doing one at a time.

Some rough numbers from the real asd/jobs repo with about 4700 files. These were measured on a local disk so the NFS numbers will be higher, and the box is shared so they bounce around.
- Max event loop blockage: the loop is blocked for max **~50ms** at a time, usually more like 15 to 25ms. That is how long it takes to walk one batch worth of directories between yields.
- Max wall clock: the whole reload lands around 5 to 11 seconds depending on box load

I chose a batch size of 16 because I ran over 500 time trials with batch sizes from 10 to 64, and they showed the wall clock was basically flat across the range but the blockage grew with batch size, so 16 gets almost all of the speedup while keeping the blockage small.

Addresses https://git.tudor.com/asd/iac/issues/1984. Bottom of a 2 PR stack, the libyaml parser speedup is #559 on top of this.