### PR TITLE
Bump ora to 0.10.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "brotli",
     "httpx",
     "jinja2",
-    "ora <0.9.0",
+    "ora >=0.10.3",
     # wheels are only available on self-hosted Github pages pypi index, use:
     #   pip install --extra-index-url https://apsis-scheduler.github.io/procstar/simple .
     "procstar >=0.7",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ aiohttp
 brotli
 httpx
 jinja2
-ora <0.9.0
+ora >=0.10.3
 pyyaml
 ruamel.yaml
 requests

--- a/uv.lock
+++ b/uv.lock
@@ -153,7 +153,7 @@ requires-dist = [
     { name = "brotli" },
     { name = "httpx" },
     { name = "jinja2" },
-    { name = "ora", specifier = "<0.9.0" },
+    { name = "ora", specifier = ">=0.10.3" },
     { name = "procstar", specifier = ">=0.7" },
     { name = "pyyaml" },
     { name = "readthedocs-sphinx-ext", marker = "extra == 'doc'" },
@@ -672,32 +672,10 @@ wheels = [
 ]
 
 [[package]]
-name = "numpy"
-version = "1.26.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010", size = 15786129, upload-time = "2024-02-06T00:26:44.495Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/94/ace0fdea5241a27d13543ee117cbc65868e82213fb31a8eb7fe9ff23f313/numpy-1.26.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9ff0f4f29c51e2803569d7a51c2304de5554655a60c5d776e35b4a41413830d0", size = 20631468, upload-time = "2024-02-05T23:48:01.194Z" },
-    { url = "https://files.pythonhosted.org/packages/20/f7/b24208eba89f9d1b58c1668bc6c8c4fd472b20c45573cb767f59d49fb0f6/numpy-1.26.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2e4ee3380d6de9c9ec04745830fd9e2eccb3e6cf790d39d7b98ffd19b0dd754a", size = 13966411, upload-time = "2024-02-05T23:48:29.038Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/a5/4beee6488160798683eed5bdb7eead455892c3b4e1f78d79d8d3f3b084ac/numpy-1.26.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d209d8969599b27ad20994c8e41936ee0964e6da07478d6c35016bc386b66ad4", size = 14219016, upload-time = "2024-02-05T23:48:54.098Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/d7/ecf66c1cd12dc28b4040b15ab4d17b773b87fa9d29ca16125de01adb36cd/numpy-1.26.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ffa75af20b44f8dba823498024771d5ac50620e6915abac414251bd971b4529f", size = 18240889, upload-time = "2024-02-05T23:49:25.361Z" },
-    { url = "https://files.pythonhosted.org/packages/24/03/6f229fe3187546435c4f6f89f6d26c129d4f5bed40552899fcf1f0bf9e50/numpy-1.26.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:62b8e4b1e28009ef2846b4c7852046736bab361f7aeadeb6a5b89ebec3c7055a", size = 13876746, upload-time = "2024-02-05T23:49:51.983Z" },
-    { url = "https://files.pythonhosted.org/packages/39/fe/39ada9b094f01f5a35486577c848fe274e374bbf8d8f472e1423a0bbd26d/numpy-1.26.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a4abb4f9001ad2858e7ac189089c42178fcce737e4169dc61321660f1a96c7d2", size = 18078620, upload-time = "2024-02-05T23:50:22.515Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/ef/6ad11d51197aad206a9ad2286dc1aac6a378059e06e8cf22cd08ed4f20dc/numpy-1.26.4-cp310-cp310-win32.whl", hash = "sha256:bfe25acf8b437eb2a8b2d49d443800a5f18508cd811fea3181723922a8a82b07", size = 5972659, upload-time = "2024-02-05T23:50:35.834Z" },
-    { url = "https://files.pythonhosted.org/packages/19/77/538f202862b9183f54108557bfda67e17603fc560c384559e769321c9d92/numpy-1.26.4-cp310-cp310-win_amd64.whl", hash = "sha256:b97fe8060236edf3662adfc2c633f56a08ae30560c56310562cb4f95500022d5", size = 15808905, upload-time = "2024-02-05T23:51:03.701Z" },
-]
-
-[[package]]
 name = "ora"
-version = "0.8.4"
+version = "0.10.3"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1e/30/3a16df6e75d31fdb99ddaa5e86d69e8876f49bf51fe995004b54a1ba092a/ora-0.8.4.tar.gz", hash = "sha256:90d246a8656215712c6c168ea8522a3df15fbff7423f13f32f4106dac63d7e71", size = 350665, upload-time = "2024-07-22T20:19:34.553Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/b1/33a1c5c3cb6b58d010c13e0c23666f82ee009e94b7861906dbce2baae3a4/ora-0.8.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0eb8bd818fb7c896d920b74fd0ff0de4b1df7b3345cb8423829d49ff0cdd25a9", size = 8438004, upload-time = "2024-07-22T20:21:18.074Z" },
-]
+sdist = { url = "https://files.pythonhosted.org/packages/96/50/34772ea6791124513bf858f411a529b7fd37547e1a2d646fb275f7596221/ora-0.10.3.tar.gz", hash = "sha256:9f17223085e99f47a24707d026c1c95439559c0be466c72788ba0ea0c2f33d17", size = 353782, upload-time = "2026-02-13T04:41:54.394Z" }
 
 [[package]]
 name = "orjson"


### PR DESCRIPTION
Fixes the calendar name shown for calendars in subdirectories of the calendar dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)