### PR TITLE
Validate job param names

### DIFF
--- a/docs/jobs.rst
+++ b/docs/jobs.rst
@@ -53,6 +53,22 @@ If `params` is omitted, the job has no parameters.
 Parameters aren't required; a job without parameters can be run repeatedly, just
 like a cron job.
 
+A parameter name must be a letter or underscore followed by letters, digits, and
+underscores, since it is used as a template variable when :ref:`binding
+<binding>` a run, as part of an `APSIS_ARG_`-prefixed environment variable for
+the run's program, and as `NAME=VALUE` on the `apsis schedule` command line.
+
+A few names that fit that rule are still not allowed, because a `{{ ... }}`
+expansion wouldn't give the argument's value:
+
+- the jinja2 literals `true`, `false`, `none`, `True`, `False`, `None`, and the
+  operator `not`
+- `self` and `loop`, which jinja2 binds itself
+- the names Apsis provides to expansion, listed under :ref:`binding`, which a
+  parameter would shadow
+
+Only these exact spellings; `TRUE` and `Self`, for instance, are fine.
+
 
 Program
 -------
@@ -181,6 +197,9 @@ following additional Ora types and functions are available:
 - `get_calendar <https://ora.readthedocs.io/en/latest/calendars.html#finding-calendars>`_
 - `from_local <https://ora.readthedocs.io/en/latest/localization.html#local-to-time>`_
 - `to_local <https://ora.readthedocs.io/en/latest/localization.html#time-to-local>`_
+
+Python's `format` builtin is available too, as are the run's own `run_id` and
+`job_id`.
 
 These functions and types allow you to perform time computations on program and
 condition dates and times.  For example, this job has a dependency on another

--- a/python/apsis/check.py
+++ b/python/apsis/check.py
@@ -1,4 +1,5 @@
 from collections import defaultdict, deque
+import re
 
 import ora
 
@@ -8,6 +9,39 @@ from apsis.runs import Instance, Run, is_template, validate_args, bind
 from apsis.scheduler import get_insts_to_schedule
 
 # -------------------------------------------------------------------------------
+
+# A param name is a Jinja2 variable in a template expansion, part of an environment
+# variable name, and `NAME=VALUE` on the `apsis schedule` command line, so it has to
+# be an identifier.
+PARAM_NAME_REGEX = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+PARAM_NAME_DESCRIPTION = "a letter or underscore followed by letters, digits, and underscores"
+
+# Identifiers a template expansion doesn't read as the param's arg: Jinja2 constants
+# and an operator, plus `self` and `loop`, which its runtime binds.  `{{ None }}`
+# expands to "None" whatever the arg says.
+PARAM_NAME_NOT_EXPANDABLE = frozenset(
+    {"False", "None", "True", "false", "loop", "none", "not", "self", "true"}
+)
+
+
+def check_param_names(params):
+    """
+    Checks that `params` are all usable as param names.
+
+    :return:
+      Generator of errors.
+    """
+
+    def show(names):
+        return ", ".join(repr(n) for n in sorted(names))
+
+    invalid = [p for p in params if PARAM_NAME_REGEX.fullmatch(p) is None]
+    if len(invalid) > 0:
+        yield f"invalid param names ({show(invalid)}): must be {PARAM_NAME_DESCRIPTION}"
+
+    reserved = [p for p in params if p in PARAM_NAME_NOT_EXPANDABLE]
+    if len(reserved) > 0:
+        yield f"invalid param names ({show(reserved)}): reserved by template expansion"
 
 
 # FIXME: Use normal protocols for this, not random APIs that need mocks.
@@ -23,6 +57,8 @@ def check_job(jobs_dir, job):
     :return:
       Generator of errors.
     """
+    yield from check_param_names(job.params)
+
     # Try scheduling a run for each schedule of each job.  This tests that
     # template expansions work, that all names and params are bound, and that
     # actions and conditions refer to valid jobs with correct args.

--- a/python/apsis/check.py
+++ b/python/apsis/check.py
@@ -5,7 +5,7 @@ import ora
 
 from apsis.cond.dependency import Dependency
 from apsis.jobs import Jobs
-from apsis.runs import Instance, Run, is_template, validate_args, bind
+from apsis.runs import BIND_ARGS, Instance, Run, is_template, validate_args, bind
 from apsis.scheduler import get_insts_to_schedule
 
 # -------------------------------------------------------------------------------
@@ -22,6 +22,11 @@ PARAM_NAME_DESCRIPTION = "a letter or underscore followed by letters, digits, an
 PARAM_NAME_NOT_EXPANDABLE = frozenset(
     {"False", "None", "True", "false", "loop", "none", "not", "self", "true"}
 )
+
+# Names Apsis provides to template expansion, which a param's arg would shadow; see
+# `runs.get_bind_args()`.  A param named `format` makes `{{ format(...) }}` elsewhere
+# in the job fail, and one named `run_id` silently displaces the run's ID.
+PARAM_NAME_PROVIDED = frozenset({"job_id", "run_id", *BIND_ARGS})
 
 
 def check_param_names(params):
@@ -42,6 +47,10 @@ def check_param_names(params):
     reserved = [p for p in params if p in PARAM_NAME_NOT_EXPANDABLE]
     if len(reserved) > 0:
         yield f"invalid param names ({show(reserved)}): reserved by template expansion"
+
+    provided = [p for p in params if p in PARAM_NAME_PROVIDED]
+    if len(provided) > 0:
+        yield f"invalid param names ({show(provided)}): provided to template expansion by Apsis"
 
 
 # FIXME: Use normal protocols for this, not random APIs that need mocks.

--- a/test/int/basic/test_check_jobs.py
+++ b/test/int/basic/test_check_jobs.py
@@ -7,7 +7,7 @@ import yaml
 
 import apsis.jobs
 from apsis.check import check_job_dependencies_scheduled
-from apsis.exc import JobsDirErrors, SchemaError
+from apsis.exc import JobError, JobsDirErrors, SchemaError
 
 DAY_IN_SEC = 86400
 
@@ -467,3 +467,33 @@ async def test_check_dependency_cycle(tmp_path):
     assert all("dependency cycle detected:" in msg for _, msg in cycle_errors)
     # The cycle should mention the job names with arrows.
     assert any("→" in msg for _, msg in cycle_errors)
+
+
+@pytest.mark.asyncio
+async def test_param_name_with_equals(tmp_path):
+    """
+    Tests that a job with a param name that is not an identifier is not loaded.
+    """
+    jobs_path = tmp_path
+    job_path = jobs_path / "job.yaml"
+
+    job = {
+        "params": ["date", "a=b"],
+        "program": {"type": "no-op"},
+    }
+    dump_yaml_file(job, job_path)
+
+    try:
+        await apsis.jobs.load_jobs_dir(jobs_path)
+    except JobsDirErrors as exc:
+        (err,) = exc.errors
+        assert isinstance(err, JobError)
+        assert err.job_id == "job"
+        assert "'a=b'" in str(err)
+    else:
+        assert False, "expected jobs dir error"
+
+    # Rename the param.  Now it should be fine.
+    job["params"] = ["date", "a_b"]
+    dump_yaml_file(job, job_path)
+    await apsis.jobs.load_jobs_dir(jobs_path)

--- a/test/unit/test_check.py
+++ b/test/unit/test_check.py
@@ -1,9 +1,13 @@
 from typing import List
 
+import pytest
+
 import apsis.check
+from apsis.check import PARAM_NAME_NOT_EXPANDABLE, check_param_names
 from apsis.cond.dependency import Dependency
 import apsis.jobs
 from apsis.jobs import InMemoryJobs, Job
+from apsis.runs import template_expand
 
 # -------------------------------------------------------------------------------
 
@@ -115,3 +119,98 @@ def test_dependency_missing_arg():
     errors = check_job(jobs, "job7")
     assert len(errors) > 0
     assert "extra" in errors[0]
+
+
+# -------------------------------------------------------------------------------
+# param names
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["a=b", "=", "date=2024-01-01", "a\0b", "with-dash", "with space", "2big", "a,b", ""],
+)
+def test_param_name_invalid(name):
+    """
+    A param name that is not an identifier is an error.
+    """
+    (error,) = check_param_names([name])
+    assert repr(name) in error
+    assert "letter or underscore" in error
+
+
+# Each non-expandable name, with a template in which it doesn't expand to the arg.
+NOT_EXPANDABLE = [
+    ("not", "{{ not }}"),
+    ("true", "{{ true }}"),
+    ("false", "{{ false }}"),
+    ("none", "{{ none }}"),
+    ("True", "{{ True }}"),
+    ("False", "{{ False }}"),
+    ("None", "{{ None }}"),
+    ("self", "{{ self }}"),
+    ("loop", "{% for _ in [1] %}{{ loop }}{% endfor %}"),
+]
+
+
+def test_param_names_not_expandable():
+    """
+    Every non-expandable name has a case below demonstrating why.
+    """
+    assert {n for n, _ in NOT_EXPANDABLE} == PARAM_NAME_NOT_EXPANDABLE
+
+
+@pytest.mark.parametrize("name,template", NOT_EXPANDABLE)
+def test_param_name_not_expandable(name, template):
+    """
+    A param name that a template expansion doesn't read as the arg is an error.
+    """
+    (error,) = check_param_names([name])
+    assert repr(name) in error
+    assert "reserved" in error
+
+    # Confirm the name really is unusable.
+    try:
+        expanded = template_expand(template, {name: "VAL"})
+    except SyntaxError:
+        return
+    assert expanded != "VAL"
+
+
+@pytest.mark.parametrize(
+    "name", ["date", "with_underscore", "UPPER", "_leading", "a1", "TRUE", "SELF", "nothing"]
+)
+def test_param_name_valid(name):
+    """
+    A param name that is an identifier is accepted, and expands to its arg.
+    """
+    assert list(check_param_names([name])) == []
+    assert template_expand("{{ " + name + " }}", {name: "VAL"}) == "VAL"
+
+
+def test_param_names_all_reported():
+    """
+    Every unusable param name is reported, with why, not just the first.
+    """
+    errors = list(check_param_names(["date", "a=b", "not", "2big"]))
+    assert len(errors) == 2
+    invalid, reserved = errors
+    assert "'2big', 'a=b'" in invalid
+    assert "letter or underscore" in invalid
+    assert "'not'" in reserved
+    assert "reserved" in reserved
+    assert not any("date" in e for e in errors)
+
+
+def test_param_name_does_not_mask_other_errors():
+    """
+    A bad param name doesn't hide the job's other errors.
+    """
+    jobs = InMemoryJobs(
+        (
+            Job("job0", params=["color"]),
+            Job("job1", params=["a=b"], conds=[Dependency("job0")]),
+        )
+    )
+    errors = check_job(jobs, "job1")
+    assert any("'a=b'" in e for e in errors)
+    assert any("missing" in e for e in errors)

--- a/test/unit/test_check.py
+++ b/test/unit/test_check.py
@@ -3,11 +3,11 @@ from typing import List
 import pytest
 
 import apsis.check
-from apsis.check import PARAM_NAME_NOT_EXPANDABLE, check_param_names
+from apsis.check import PARAM_NAME_NOT_EXPANDABLE, PARAM_NAME_PROVIDED, check_param_names
 from apsis.cond.dependency import Dependency
 import apsis.jobs
 from apsis.jobs import InMemoryJobs, Job
-from apsis.runs import template_expand
+from apsis.runs import Instance, Run, get_bind_args, template_expand
 
 # -------------------------------------------------------------------------------
 
@@ -176,6 +176,38 @@ def test_param_name_not_expandable(name, template):
     assert expanded != "VAL"
 
 
+def test_param_names_provided():
+    """
+    The provided names are exactly what binding makes available.
+    """
+    run = Run(Instance("job", {}))
+    assert PARAM_NAME_PROVIDED == set(get_bind_args(run))
+
+
+@pytest.mark.parametrize("name", sorted(PARAM_NAME_PROVIDED))
+def test_param_name_provided(name):
+    """
+    A param name that Apsis provides to template expansion is an error.
+    """
+    (error,) = check_param_names([name])
+    assert repr(name) in error
+    assert "provided" in error
+
+
+def test_param_name_provided_shadows():
+    """
+    A param that shadows a provided name breaks the job's other expansions.
+    """
+    run = Run(Instance("job", {"format": "2024-01-01", "run_id": "r1"}))
+    args = get_bind_args(run)
+    # The param wins over what Apsis provides.
+    assert template_expand("{{ format }}", args) == "2024-01-01"
+    assert template_expand("{{ run_id }}", args) == "r1"
+    # So `format` is no longer callable elsewhere in the job.
+    with pytest.raises(TypeError):
+        template_expand("{{ format(Date(2024, 1, 1), '%Y%m%d') }}", args)
+
+
 @pytest.mark.parametrize(
     "name", ["date", "with_underscore", "UPPER", "_leading", "a1", "TRUE", "SELF", "nothing"]
 )
@@ -191,13 +223,15 @@ def test_param_names_all_reported():
     """
     Every unusable param name is reported, with why, not just the first.
     """
-    errors = list(check_param_names(["date", "a=b", "not", "2big"]))
-    assert len(errors) == 2
-    invalid, reserved = errors
+    errors = list(check_param_names(["date", "a=b", "not", "2big", "format"]))
+    assert len(errors) == 3
+    invalid, reserved, provided = errors
     assert "'2big', 'a=b'" in invalid
     assert "letter or underscore" in invalid
     assert "'not'" in reserved
     assert "reserved" in reserved
+    assert "'format'" in provided
+    assert "provided" in provided
     assert not any("date" in e for e in errors)
 
 


### PR DESCRIPTION
Param names were unvalidated, but a param name has to work as a jinja2 template variable, as part of the run program's `APSIS_ARG_<name>` environment variable, and as `NAME=VALUE` on the `apsis schedule` command line.  A name that doesn't fit works in some of those and fails silently in the others: a param `a=b` arrives as `APSIS_ARG_a=b=<value>` and reads back as the param `a`, so a Python and a shell program in the same run can see different values for `a`.

Require a param name to be a letter or underscore followed by letters, digits, and underscores, and reject the nineteen identifiers a `{{ ... }}` expansion wouldn't give the arg's value for: the jinja2 constants and `not`, the runtime's `self` and `loop`, and the ten names Apsis itself provides to expansion (`run_id`, `job_id`, `format`, and the Ora types and functions), which a param would shadow.

The check goes in `check_job`, so `load_jobs_dir` refuses a jobs dir containing one and `apsisctl check-jobs` reports it alongside the job's other errors.  Not in `Job.__init__`, which is also the read path for stored ad hoc jobs.  Stored runs and jobs are never re-checked, so nothing existing breaks, and nothing in either repo's jobs is rejected today.

Docs under *Params* in `docs/jobs.rst`; tests in `test/unit/test_check.py` and `test/int/basic/test_check_jobs.py`.
